### PR TITLE
fix transfer, use maxOpenPosition

### DIFF
--- a/contracts/PerpdexLongToken.sol
+++ b/contracts/PerpdexLongToken.sol
@@ -6,8 +6,6 @@ import { SafeCast } from "@openzeppelin/contracts/utils/SafeCast.sol";
 import { IPerpdexExchange } from "../deps/perpdex-contract/contracts/interface/IPerpdexExchange.sol";
 import { PerpdexTokenBase } from "./PerpdexTokenBase.sol";
 
-import "hardhat/console.sol";
-
 contract PerpdexLongToken is PerpdexTokenBase {
     using SafeCast for int256;
 

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -119,7 +119,6 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
         _validateOpenPositionResult(isBaseToQuote, isExactInput, amount, base, quote);
     }
 
-    // TODO: do we need this?
     function _validateOpenPositionResult(
         bool isBaseToQuote,
         bool isExactInput,
@@ -183,12 +182,6 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
                     IERC20Metadata(IPerpdexExchange(IPerpdexMarket(marketArg).exchange()).settlementToken()).symbol()
                 )
             );
-    }
-
-    function _isMarketEmptyPool() internal view returns (bool) {
-        // TODO:
-        // return IPerpdexMarket(market).poolInfo().totalLiquidity == 0;
-        return false;
     }
 
     // https://github.com/OpenZeppelin/openzeppelin-contracts/commit/c5a6cae8981d8005e22243b681745af92d44d1fc

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -137,7 +137,16 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
         }
     }
 
-    function _transferFrom(
+    function _depositToPerpdex(uint256 amount) internal {
+        IERC20(asset).approve(exchange, type(uint256).max);
+        IPerpdexExchange(exchange).deposit(amount);
+    }
+
+    function _assetSafeTransfer(address to, uint256 amount) internal {
+        SafeERC20.safeTransfer(IERC20(asset), to, amount);
+    }
+
+    function _assetSafeTransferFrom(
         address from,
         address to,
         uint256 amount
@@ -171,5 +180,19 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
         // TODO:
         // return IPerpdexMarket(market).poolInfo().totalLiquidity == 0;
         return false;
+    }
+
+    // https://github.com/OpenZeppelin/openzeppelin-contracts/commit/c5a6cae8981d8005e22243b681745af92d44d1fc
+    function _spendAllowance(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal virtual {
+        uint256 currentAllowance = allowance(owner, spender);
+        if (currentAllowance != type(uint256).max) {
+            // solhint-disable-next-line reason-string
+            require(amount <= currentAllowance, "ERC20: transfer amount exceeds allowance");
+            _approve(owner, spender, currentAllowance - amount);
+        }
     }
 }

--- a/contracts/lib/PerpdexTokenMath.sol
+++ b/contracts/lib/PerpdexTokenMath.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.7.6;
+pragma abicoder v2;
+
+library PerpdexTokenMath {
+    function minUint256(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+}

--- a/contracts/test/TestPerpdexTokenBase.sol
+++ b/contracts/test/TestPerpdexTokenBase.sol
@@ -36,6 +36,7 @@ contract TestPerpdexTokenBase is PerpdexTokenBase {
         address owner
     ) external override returns (uint256 shares) {}
 
+    // for unit test
     function validateOpenPositionResult(
         bool isBaseToQuote,
         bool isExactInput,
@@ -44,5 +45,14 @@ contract TestPerpdexTokenBase is PerpdexTokenBase {
         int256 quote
     ) external pure {
         return _validateOpenPositionResult(isBaseToQuote, isExactInput, amount, base, quote);
+    }
+
+    // for unit test
+    function spendAllowance(
+        address owner,
+        address spender,
+        uint256 amount
+    ) external {
+        _spendAllowance(owner, spender, amount);
     }
 }

--- a/test/longToken/base.test.ts
+++ b/test/longToken/base.test.ts
@@ -83,7 +83,7 @@ describe("PerpdexLongToken base", async () => {
 
     describe("convertToShares", async () => {
         beforeEach(async () => {
-            // approve max
+            // alice approve longToken of max assets
             await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
             await weth.approveForce(longToken.address, exchange.address, ethers.constants.MaxUint256)
         })
@@ -128,7 +128,7 @@ describe("PerpdexLongToken base", async () => {
 
     describe("convertToAssets", async () => {
         beforeEach(async () => {
-            // approve max
+            // alice approve longToken of max assets
             await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
             await weth.approveForce(longToken.address, exchange.address, ethers.constants.MaxUint256)
         })

--- a/test/longToken/deposit.test.ts
+++ b/test/longToken/deposit.test.ts
@@ -47,27 +47,40 @@ describe("PerpdexLongToken deposit", async () => {
 
     describe("maxDeposit", async () => {
         ;[
-            // {
-            //   title: "TODO: returns 0 when pool liquidity is zero",
-            //   pool: {
-            //     base: "0",
-            //     quote: "0",
-            //   },
-            //   expected: "0",
-            // },
             {
-                title: "returns max int",
+                title: "returns 0 when market is not allowed",
+                pool: {
+                    base: "0",
+                    quote: "0",
+                },
+                isMarkeAllowed: false,
+                expected: "0",
+            },
+            {
+                title: "returns 0 when pool liquidity is zero",
+                pool: {
+                    base: "0",
+                    quote: "0",
+                },
+                expected: "0",
+            },
+            {
+                title: "succeeds",
                 pool: {
                     base: "10",
                     quote: "10",
                 },
-                expected: ethers.constants.MaxInt256,
+                expected: "0.240999270514668206",
             },
         ].forEach(test => {
             it(test.title, async () => {
                 await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.base))
 
-                expect(await longToken.maxDeposit(alice.address)).to.eq(test.expected)
+                if (test.isMarkeAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                }
+
+                expect(await longToken.maxDeposit(alice.address)).to.eq(parseAssets(test.expected))
             })
         })
     })

--- a/test/longToken/deposit.test.ts
+++ b/test/longToken/deposit.test.ts
@@ -70,7 +70,7 @@ describe("PerpdexLongToken deposit", async () => {
                     base: "10",
                     quote: "10",
                 },
-                expected: "0.240999270514668206",
+                expected: "0.246950765959598383",
             },
         ].forEach(test => {
             it(test.title, async () => {
@@ -193,7 +193,7 @@ describe("PerpdexLongToken deposit", async () => {
                 },
                 aliceQuoteAssets: "1000",
                 depositAssets: "100",
-                revertedWith: "TODO: ?",
+                revertedWith: "PLT_D: deposit more than max", // maxDeposit == 0
             },
             {
                 title: "reverts when assets is zero",

--- a/test/longToken/fixtures.ts
+++ b/test/longToken/fixtures.ts
@@ -12,16 +12,11 @@ export interface PerpdexExchangeFixture {
     owner: Wallet
     alice: Wallet
     bob: Wallet
+    charlie: Wallet
 }
 
-interface Params {
-    linear: Boolean
-}
-
-export function createPerpdexExchangeFixture(
-    params: Params = { linear: false },
-): (wallets, provider) => Promise<PerpdexExchangeFixture> {
-    return async ([owner, alice, bob], provider): Promise<PerpdexExchangeFixture> => {
+export function createPerpdexExchangeFixture(): (wallets, provider) => Promise<PerpdexExchangeFixture> {
+    return async ([owner, alice, bob, charlie], provider): Promise<PerpdexExchangeFixture> => {
         let settlementToken = hre.ethers.constants.AddressZero
         const tokenFactory = await ethers.getContractFactory("TestERC20")
         let weth = (await tokenFactory.deploy("TestWETH", "WETH", 18)) as TestERC20
@@ -60,6 +55,7 @@ export function createPerpdexExchangeFixture(
             owner,
             alice,
             bob,
+            charlie,
         }
     }
 }

--- a/test/longToken/mint.test.ts
+++ b/test/longToken/mint.test.ts
@@ -70,7 +70,7 @@ describe("PerpdexLongToken mint", async () => {
                     base: "10",
                     quote: "10",
                 },
-                expected: "0.246950765959598383",
+                expected: "0.240999270514668206",
             },
         ].forEach(test => {
             it(test.title, async () => {
@@ -112,7 +112,7 @@ describe("PerpdexLongToken mint", async () => {
                 },
                 aliceQuoteAssets: "1000",
                 mintShares: "100",
-                revertedWith: "PL_SD: output is zero",
+                revertedWith: "SafeMath: subtraction overflow",
             },
             {
                 title: "reverts when assets is zero",
@@ -132,7 +132,7 @@ describe("PerpdexLongToken mint", async () => {
                 },
                 aliceQuoteAssets: "1000",
                 mintShares: "100",
-                revertedWith: "PLL_C: price limit",
+                revertedWith: "SafeMath: subtraction overflow",
             },
             {
                 title: "succeeds",
@@ -194,7 +194,7 @@ describe("PerpdexLongToken mint", async () => {
                 },
                 aliceQuoteAssets: "1000",
                 mintShares: "100",
-                revertedWith: "TODO: ?",
+                revertedWith: "PLT_M: mint more than max", // maxMint == 0
             },
             {
                 title: "reverts when assets is zero",

--- a/test/longToken/mint.test.ts
+++ b/test/longToken/mint.test.ts
@@ -47,28 +47,41 @@ describe("PerpdexLongToken mint", async () => {
 
     describe("maxMint", async () => {
         ;[
-            // {
-            //   title: "TODO: returns 0 when pool liquidity is zero",
-            //   pool: {
-            //     base: "0",
-            //     quote: "0",
-            //   },
-            //   expected: 0,
-            // },
             {
-                title: "returns max uint",
+                title: "returns 0 when market is not allowed",
+                pool: {
+                    base: "0",
+                    quote: "0",
+                },
+                isMarkeAllowed: false,
+                expected: "0",
+            },
+            {
+                title: "returns 0 when pool liquidity is zero",
+                pool: {
+                    base: "0",
+                    quote: "0",
+                },
+                expected: "0",
+            },
+            {
+                title: "succeeds",
                 pool: {
                     base: "10",
                     quote: "10",
                 },
-                expected: ethers.constants.MaxUint256,
+                expected: "0.246950765959598383",
             },
         ].forEach(test => {
             it(test.title, async () => {
                 // init pool
                 await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.base))
 
-                expect(await longToken.maxMint(alice.address)).to.eq(test.expected)
+                if (test.isMarkeAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                }
+
+                expect(await longToken.maxMint(alice.address)).to.eq(parseShares(test.expected))
             })
         })
     })

--- a/test/longToken/mint.test.ts
+++ b/test/longToken/mint.test.ts
@@ -88,63 +88,83 @@ describe("PerpdexLongToken mint", async () => {
 
     describe("previewMint", async () => {
         beforeEach(async () => {
-            // approve max
+            // alice approve longToken of max assets
             await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
             await weth.approveForce(longToken.address, exchange.address, ethers.constants.MaxUint256)
         })
         ;[
             {
-                title: "returns 0 when shares is zero",
+                title: "reverts when market is not allowed",
                 pool: {
-                    base: "1",
-                    quote: "1",
+                    base: "10",
+                    quote: "10",
                 },
-                aliceAssetsBefore: "100",
+                isMarkeAllowed: false,
+                aliceQuoteAssets: "1000",
+                mintShares: "100",
+                revertedWith: "PE_CMA: market not allowed",
+            },
+            {
+                title: "reverts when liquidity is zero",
+                pool: {
+                    base: "0",
+                    quote: "0",
+                },
+                aliceQuoteAssets: "1000",
+                mintShares: "100",
+                revertedWith: "PL_SD: output is zero",
+            },
+            {
+                title: "reverts when assets is zero",
+                pool: {
+                    base: "10",
+                    quote: "10",
+                },
+                aliceQuoteAssets: "1000",
                 mintShares: "0",
-                assetsAmount: "0",
+                revertedWith: "PL_SD: output is zero",
             },
-            // TODO:
-            // {
-            //   title: "returns patial assets when pool liquidity is not enought",
-            //   pool: {
-            //     base: "1",
-            //     quote: "1",
-            //   },
-            //   aliceAssetsBefore: "100",
-            //   mintShares: "10",
-            //   assetsAmount: "123",
-            // },
             {
-                title: "returns ideal assets even if alice's assets is not enough",
+                title: "reverts when assets is too large",
+                pool: {
+                    base: "10",
+                    quote: "10",
+                },
+                aliceQuoteAssets: "1000",
+                mintShares: "100",
+                revertedWith: "PLL_C: price limit",
+            },
+            {
+                title: "succeeds",
                 pool: {
                     base: "10000",
                     quote: "10000",
                 },
-                aliceAssetsBefore: "5",
+                aliceQuoteAssets: "500",
                 mintShares: "10",
-                assetsAmount: "10.010010010010010011",
-            },
-            {
-                title: "returns ideal assets when alice's assets is enough",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                aliceAssetsBefore: "100",
-                mintShares: "10",
-                assetsAmount: "10.010010010010010011",
+                depositedAssets: "10.010010010010010011",
             },
         ].forEach(test => {
             it(test.title, async () => {
                 await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.base))
 
-                // alice balance
-                await weth.connect(owner).mint(alice.address, parseAssets(test.aliceAssetsBefore))
+                if (test.isMarkeAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                }
 
-                // alice deposit preview
-                var mintShares = parseAssets(test.mintShares)
-                var assetsAmount = parseShares(test.assetsAmount)
-                expect(await longToken.connect(alice).previewMint(mintShares)).to.eq(assetsAmount)
+                // alice balance
+                await weth.connect(owner).mint(alice.address, parseAssets(test.aliceQuoteAssets))
+
+                // alice preview mint
+                var mintShares = parseShares(test.mintShares)
+                var subject = longToken.connect(alice).previewMint(mintShares)
+
+                // assert
+                if (test.revertedWith !== void 0) {
+                    await expect(subject).to.revertedWith(test.revertedWith)
+                } else {
+                    expect(await subject).to.eq(parseShares(test.depositedAssets))
+                }
             })
         })
     })

--- a/test/longToken/redeem.test.ts
+++ b/test/longToken/redeem.test.ts
@@ -236,7 +236,7 @@ describe("PerpdexLongToken redeem", async () => {
                 revertedWith: "PLT_R: redeem is zero",
             },
             {
-                title: "reverts when shares is large",
+                title: "reverts when shares is more than max",
                 pool: {
                     base: "10000",
                     quote: "10000",
@@ -288,7 +288,6 @@ describe("PerpdexLongToken redeem", async () => {
                     await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
                 }
 
-                // alice deposits
                 // owner remove liquidity
                 if (test.removeLiquidity > 0) {
                     await exchange.connect(owner).removeLiquidity({
@@ -301,7 +300,7 @@ describe("PerpdexLongToken redeem", async () => {
                     })
                 }
 
-                // alice withdraw
+                // alice redeem
                 var assetsBefore = await weth.balanceOf(alice.address)
                 var sharesBefore = await longToken.balanceOf(alice.address)
                 var totalAssetsBefore = await longToken.totalAssets()

--- a/test/longToken/redeem.test.ts
+++ b/test/longToken/redeem.test.ts
@@ -323,4 +323,175 @@ describe("PerpdexLongToken redeem", async () => {
             })
         })
     })
+
+    describe("previewRedeem and redeem", async () => {
+        beforeEach(async () => {
+            // alice approve longToken of max assets
+            await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
+            // bob approve longToken of max assets
+            await weth.approveForce(bob.address, longToken.address, ethers.constants.MaxUint256)
+        })
+        ;[
+            {
+                title: "both reverts when market is not allowed",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarkeAllowed: false,
+                depositAssets: "10",
+                withdrawAssets: "5",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "alice",
+                receiver: "alice",
+                revertedWithPreview: "PE_CMA: market not allowed",
+                revertedWith: "PLT_W: withdraw more than max", // maxWithdraw == 0
+            },
+            {
+                title: "both reverts when assets is zero",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarkeAllowed: true,
+                depositAssets: "10",
+                withdrawAssets: "0",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "alice",
+                receiver: "alice",
+                revertedWithPreview: "PL_SD: output is zero",
+                revertedWith: "PLT_W: withdraw is zero",
+            },
+            {
+                title: "withdraw reverts and preview succeeds when assets is more than max",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarkeAllowed: true,
+                depositAssets: "10",
+                withdrawAssets: "20",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "alice",
+                receiver: "alice",
+                burnedSharesPreview: "20.000020000020000021",
+                revertedWith: "PLT_W: withdraw more than max",
+            },
+            {
+                title: "withdraw reverts and preview succeeds when alice withdraws unapproved bob's assets",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarkeAllowed: true,
+                depositAssets: "10",
+                withdrawAssets: "9.9",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "bob",
+                receiver: "alice",
+                burnedSharesPreview: "9.890010989999990110",
+                revertedWith: "ERC20: transfer amount exceeds allowance",
+            },
+            {
+                title: "succeeds when alice withdraws approved bob's assets to alice",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarkeAllowed: true,
+                depositAssets: "10",
+                withdrawAssets: "9.9",
+                ownerAllowance: "9.891",
+                caller: "alice",
+                owner: "bob",
+                receiver: "alice",
+                burnedSharesPreview: "9.890010989999990110",
+                burnedShares: "9.890010989999990110",
+            },
+            {
+                title: "succeeds when alice withdraws approved bob's assets to charlie",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarkeAllowed: true,
+                depositAssets: "10",
+                withdrawAssets: "9.9",
+                ownerAllowance: "9.891",
+                caller: "alice",
+                owner: "bob",
+                receiver: "charlie",
+                burnedSharesPreview: "9.890010989999990110",
+                burnedShares: "9.890010989999990110",
+            },
+        ].forEach(test => {
+            it(test.title, async () => {
+                // pool
+                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.base))
+
+                var caller = toWallet(test.caller)
+                var owner_ = toWallet(test.owner)
+                var receiver = toWallet(test.receiver)
+
+                // owner_ deposit
+                var depositAssets = parseAssets(test.depositAssets)
+                await weth.connect(owner).mint(owner_.address, depositAssets)
+                await longToken.connect(owner_).deposit(parseAssets(test.depositAssets), owner_.address)
+
+                // owner_ approves caller
+                await longToken.connect(owner_).approve(caller.address, parseShares(test.ownerAllowance))
+
+                // hold before states
+                var ownerSharesBefore = await longToken.balanceOf(owner_.address)
+                var receiverAssetsBefore = await weth.balanceOf(receiver.address)
+                var totalAssetsBefore = await longToken.totalAssets()
+                var totalSharesBefore = await longToken.totalSupply()
+
+                // change market allowance
+                if (test.isMarkeAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                }
+
+                // caller previews and withdraws
+                var withdrawAssets = parseAssets(test.withdrawAssets)
+                var previewSubject = longToken.connect(caller).previewWithdraw(withdrawAssets)
+                var withdrawSubject = longToken
+                    .connect(caller)
+                    .withdraw(withdrawAssets, receiver.address, owner_.address)
+
+                // assert withdraw
+                if (test.revertedWith !== void 0) {
+                    // preview
+                    if (test.revertedWithPreview !== void 0) {
+                        await expect(previewSubject).to.revertedWith(test.revertedWithPreview)
+                    } else {
+                        expect(await previewSubject).to.equal(parseShares(test.burnedSharesPreview))
+                    }
+                    // withdraw
+                    await expect(withdrawSubject).to.revertedWith(test.revertedWith)
+                } else {
+                    var burnedShares = parseShares(test.burnedShares)
+                    // event
+                    expect(await withdrawSubject)
+                        .to.emit(longToken, "Withdraw")
+                        .withArgs(caller.address, receiver.address, owner.address, withdrawAssets, burnedShares)
+
+                    // share
+                    expect(await longToken.totalSupply()).to.eq(totalSharesBefore.sub(burnedShares))
+                    expect(await longToken.balanceOf(owner_.address)).to.eq(ownerSharesBefore.sub(burnedShares))
+
+                    // asset
+                    expect(await longToken.totalAssets()).to.lt(totalAssetsBefore)
+                    expect(await weth.balanceOf(receiver.address)).to.eq(receiverAssetsBefore.add(withdrawAssets))
+
+                    // preview >= burned
+                    expect(await previewSubject).to.eq(parseShares(test.burnedSharesPreview))
+                }
+            })
+        })
+    })
 })

--- a/test/longToken/redeem.test.ts
+++ b/test/longToken/redeem.test.ts
@@ -247,18 +247,6 @@ describe("PerpdexLongToken redeem", async () => {
                 redeemShares: "100",
                 revertedWith: "PLT_R: redeem more than max",
             },
-            // TODO: overflow occurred when removing liquidity
-            // {
-            //     title: "reverts when pool does not have enough liquidity",
-            //     pool: {
-            //         base: "100",
-            //         quote: "100",
-            //     },
-            //     depositAssets: "1",
-            //     removeLiquidity: 100e18,
-            //     redeemShares: "0.5",
-            //     revertedWith: "TL_OP: normal order price limit",
-            // },
             {
                 title: "succeeds",
                 pool: {

--- a/test/longToken/withdraw.test.ts
+++ b/test/longToken/withdraw.test.ts
@@ -120,17 +120,6 @@ describe("PerpdexLongToken withdraw", async () => {
                 revertedWithPreview: "PE_CMA: market not allowed",
                 revertedWith: "PLT_W: withdraw more than max", // maxWithdraw == 0
             },
-            // {
-            //     title: "TODO: reverts when liquidity is zero",
-            //     pool: {
-            //         base: "100",
-            //         quote: "100",
-            //     },
-            //     depositAssets: "1",
-            //     removeLiquidity: 100e18, // will cause error
-            //     withdrawAssets: "0.5",
-            //     revertedWith: "TL_OP: normal order price limit",
-            // },
             {
                 title: "when assets is zero",
                 pool: {

--- a/test/perpdexBaseToken/spendAllowance.test.ts
+++ b/test/perpdexBaseToken/spendAllowance.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { expect } from "chai"
+import { BigNumber, Wallet } from "ethers"
+import { ethers, waffle } from "hardhat"
+import { TestPerpdexTokenBase } from "../../typechain"
+import { createPerpdexTokenBaseFixture } from "./fixtures"
+
+describe("PerpdexTokenBase.", async () => {
+    let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+    let fixture
+
+    let tokenBase: TestPerpdexTokenBase
+    let alice: Wallet
+    let bob: Wallet
+
+    function toWallet(who: string) {
+        if (who === "alice") {
+            return alice
+        }
+        if (who === "bob") {
+            return bob
+        }
+    }
+
+    beforeEach(async () => {
+        fixture = await loadFixture(createPerpdexTokenBaseFixture())
+
+        tokenBase = fixture.perpdexTokenBase
+        alice = fixture.alice
+        bob = fixture.bob
+    })
+
+    describe("_spendAllowance", async () => {
+        ;[
+            {
+                title: "does not change allowance when allowance is max",
+                ownerShares: BigNumber.from(100),
+                ownerAllowance: ethers.constants.MaxUint256,
+                caller: "alice",
+                owner: "bob",
+                amount: BigNumber.from(10),
+                ownerAllowanceAfter: ethers.constants.MaxUint256,
+            },
+            {
+                title: "spends amount of allowance when amount >= allowance",
+                ownerShares: BigNumber.from(100),
+                ownerAllowance: BigNumber.from(50),
+                caller: "alice",
+                owner: "bob",
+                amount: BigNumber.from(10),
+                ownerAllowanceAfter: BigNumber.from(50 - 10),
+            },
+            {
+                title: "reverts when amount < allowance",
+                ownerShares: BigNumber.from(100),
+                ownerAllowance: BigNumber.from(50),
+                caller: "alice",
+                owner: "bob",
+                amount: BigNumber.from(100),
+                revertedWith: "ERC20: transfer amount exceeds allowance",
+            },
+        ].forEach(test => {
+            it(test.title, async function () {
+                var caller = toWallet(test.caller)
+                var owner_ = toWallet(test.owner)
+
+                // owner approves caller
+                tokenBase.connect(owner_).approve(caller.address, test.ownerAllowance)
+
+                var subject = tokenBase.connect(caller).spendAllowance(owner_.address, caller.address, test.amount)
+                if (test.revertedWith !== void 0) {
+                    await expect(subject).to.revertedWith(test.revertedWith)
+                } else {
+                    await subject
+                    expect(await tokenBase.allowance(owner_.address, caller.address)).to.eq(test.ownerAllowanceAfter)
+                }
+            })
+        })
+    })
+})


### PR DESCRIPTION
## changes
- change transfer logic
- change maxXXX logic (use maxOpenPosition)
- change preview logic (use previewOpenPosition)
- change tests
- add `_spendAllowance(owner, msg.sender, shares)` test
- add allowance tests

## todo
- review
- one complicated test
  - this line: https://github.com/perpdex/perpdex-stablecoin/pull/6/files#diff-a472d6e0cb90e10c7dd94671e7ca0a3e1bdb386a7075e4371ffdf829a9d41935R41
  - this reverts never occured if perpdex is green, so must mock perpdex to behave irregular to cover this line