### PR TITLE
wip decimals different from 18 test

### DIFF
--- a/contracts/PerpdexLongToken.sol
+++ b/contracts/PerpdexLongToken.sol
@@ -125,7 +125,7 @@ contract PerpdexLongToken is PerpdexTokenBase {
 
     function maxWithdraw(address owner) public view override returns (uint256 maxAssets) {
         maxAssets = _maxTrade(true, true);
-        (bool success, uint256 previewAssets) = _tryPreviewTrade(true, false, balanceOf(owner));
+        (bool success, uint256 previewAssets) = _tryPreviewTrade(true, true, balanceOf(owner));
         if (success) {
             maxAssets = Math.min(maxAssets, previewAssets);
         }

--- a/contracts/PerpdexLongToken.sol
+++ b/contracts/PerpdexLongToken.sol
@@ -9,7 +9,7 @@ import { PerpdexTokenBase } from "./PerpdexTokenBase.sol";
 
 // This class should be responsible for the high layers and not the low layers
 // Specifically, you should not rely directly on decimals, WETH, Perpdex
-// Let Perpdex TokenBase absorb those specifications
+// Let PerpdexTokenBase absorb those specifications
 contract PerpdexLongToken is PerpdexTokenBase {
     using SafeCast for int256;
     using SafeMath for uint256;

--- a/contracts/PerpdexLongToken.sol
+++ b/contracts/PerpdexLongToken.sol
@@ -14,7 +14,11 @@ contract PerpdexLongToken is PerpdexTokenBase {
     using SafeCast for int256;
     using SafeMath for uint256;
 
-    constructor(address marketArg, address wethArg) PerpdexTokenBase(marketArg, "PerpDEX Long ", "pl", wethArg) {}
+    constructor(
+        address marketArg,
+        address wethArg,
+        string memory nativeTokenSymbol
+    ) PerpdexTokenBase(marketArg, "PerpDEX Long ", "pl", nativeTokenSymbol, wethArg) {}
 
     function depositETH(address receiver) external payable onlyWeth nonReentrant returns (uint256) {
         return _doDeposit(msg.value, receiver);

--- a/contracts/PerpdexLongToken.sol
+++ b/contracts/PerpdexLongToken.sol
@@ -145,7 +145,7 @@ contract PerpdexLongToken is PerpdexTokenBase {
         _burn(owner, shares);
 
         // withdraw
-        _withdrawFromPerpdex(_convertToPerpdexDecimals(assets));
+        _withdrawFromPerpdex(assets);
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }

--- a/contracts/PerpdexLongToken.sol
+++ b/contracts/PerpdexLongToken.sol
@@ -107,7 +107,7 @@ contract PerpdexLongToken is PerpdexTokenBase {
         _burn(owner, shares);
 
         // withdraw
-        IPerpdexExchange(exchange).withdraw(assets);
+        IPerpdexExchange(exchange).withdraw(_convertToPerpdexDecimals(assets));
         _assetSafeTransfer(receiver, assets);
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);

--- a/contracts/PerpdexLongToken.sol
+++ b/contracts/PerpdexLongToken.sol
@@ -15,7 +15,7 @@ contract PerpdexLongToken is PerpdexTokenBase {
         _assetSafeTransferFrom(msg.sender, address(this), assets);
         _depositToPerpdex(assets);
 
-        shares = _openPosition(false, true, assets);
+        shares = _trade(false, true, assets);
 
         _mint(receiver, shares);
 
@@ -28,7 +28,7 @@ contract PerpdexLongToken is PerpdexTokenBase {
         _assetSafeTransferFrom(msg.sender, address(this), assets);
         _depositToPerpdex(assets);
 
-        uint256 oppositeAmount = _openPosition(false, false, shares);
+        uint256 oppositeAmount = _trade(false, false, shares);
         // assets not fully used
         require(oppositeAmount == assets, "PLT_M: (never reach) ANFU");
 
@@ -42,7 +42,7 @@ contract PerpdexLongToken is PerpdexTokenBase {
         address receiver,
         address owner
     ) external override returns (uint256 shares) {
-        shares = _openPosition(true, false, assets);
+        shares = _trade(true, false, assets);
 
         _withdraw(owner, receiver, shares, assets);
     }
@@ -52,25 +52,25 @@ contract PerpdexLongToken is PerpdexTokenBase {
         address receiver,
         address owner
     ) external override returns (uint256 assets) {
-        assets = _openPosition(true, true, shares);
+        assets = _trade(true, true, shares);
 
         _withdraw(owner, receiver, shares, assets);
     }
 
     function previewDeposit(uint256 assets) external view override returns (uint256 shares) {
-        shares = _previewOpenPosition(false, true, assets);
+        shares = _previewTrade(false, true, assets);
     }
 
     function previewMint(uint256 shares) public view override returns (uint256 assets) {
-        assets = _previewOpenPosition(false, false, shares);
+        assets = _previewTrade(false, false, shares);
     }
 
     function previewWithdraw(uint256 assets) public view override returns (uint256 shares) {
-        shares = _previewOpenPosition(true, false, assets);
+        shares = _previewTrade(true, false, assets);
     }
 
     function previewRedeem(uint256 shares) external view override returns (uint256 assets) {
-        assets = _previewOpenPosition(true, true, shares);
+        assets = _previewTrade(true, true, shares);
     }
 
     function _withdraw(

--- a/contracts/PerpdexLongToken.sol
+++ b/contracts/PerpdexLongToken.sol
@@ -7,6 +7,9 @@ import { SafeCast } from "@openzeppelin/contracts/utils/SafeCast.sol";
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 import { PerpdexTokenBase } from "./PerpdexTokenBase.sol";
 
+// This class should be responsible for the high layers and not the low layers
+// Specifically, you should not rely directly on decimals, WETH, Perpdex
+// Let Perpdex TokenBase absorb those specifications
 contract PerpdexLongToken is PerpdexTokenBase {
     using SafeCast for int256;
     using SafeMath for uint256;

--- a/contracts/PerpdexLongToken.sol
+++ b/contracts/PerpdexLongToken.sol
@@ -116,15 +116,15 @@ contract PerpdexLongToken is PerpdexTokenBase {
     }
 
     function maxDeposit(address) public view override returns (uint256 maxAssets) {
-        return _maxTrade(false, true);
-    }
-
-    function maxMint(address) public view override returns (uint256 maxShares) {
         return _maxTrade(false, false);
     }
 
+    function maxMint(address) public view override returns (uint256 maxShares) {
+        return _maxTrade(false, true);
+    }
+
     function maxWithdraw(address owner) public view override returns (uint256 maxAssets) {
-        maxAssets = _maxTrade(true, false);
+        maxAssets = _maxTrade(true, true);
         (bool success, uint256 previewAssets) = _tryPreviewTrade(true, false, balanceOf(owner));
         if (success) {
             maxAssets = Math.min(maxAssets, previewAssets);
@@ -132,7 +132,7 @@ contract PerpdexLongToken is PerpdexTokenBase {
     }
 
     function maxRedeem(address owner) public view override returns (uint256 maxShares) {
-        return Math.min(balanceOf(owner), _maxTrade(true, true));
+        return Math.min(balanceOf(owner), _maxTrade(true, false));
     }
 
     function _doWithdraw(

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -22,6 +22,9 @@ abstract contract PerpdexTokenBase is IERC4626, ReentrancyGuard, ERC20 {
     address public immutable market;
     address public immutable exchange;
     address public immutable weth;
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
 
     modifier onlyWeth() {
         require(weth != address(0), "PTB_OW: weth is not available");
@@ -33,7 +36,7 @@ abstract contract PerpdexTokenBase is IERC4626, ReentrancyGuard, ERC20 {
         string memory namePrefix,
         string memory symbolPrefix,
         address wethArg
-    ) ERC20(_getERC20Name(marketArg, namePrefix), _getERC20Symbol(marketArg, symbolPrefix)) {
+    ) {
         address exchangeVar = IPerpdexMarket(marketArg).exchange();
         address settlementToken = IPerpdexExchange(exchangeVar).settlementToken();
         address assetVar;
@@ -50,6 +53,11 @@ abstract contract PerpdexTokenBase is IERC4626, ReentrancyGuard, ERC20 {
         market = marketArg;
         weth = wethArg;
         exchange = exchangeVar;
+
+        // ERC20
+        _name = _getERC20Name(marketArg, assetVar, namePrefix);
+        _symbol = _getERC20Symbol(marketArg, assetVar, symbolPrefix);
+        _decimals = 18;
     }
 
     // make ERC20 external functions non reentrant
@@ -260,25 +268,23 @@ abstract contract PerpdexTokenBase is IERC4626, ReentrancyGuard, ERC20 {
         }
     }
 
-    function _getERC20Name(address marketArg, string memory namePrefix) private view returns (string memory) {
+    function _getERC20Name(
+        address marketArg,
+        address assetVar,
+        string memory namePrefix
+    ) private view returns (string memory) {
         return
-            string(
-                abi.encodePacked(
-                    namePrefix,
-                    IPerpdexMarket(marketArg).symbol(),
-                    IERC20Metadata(IPerpdexExchange(IPerpdexMarket(marketArg).exchange()).settlementToken()).symbol()
-                )
-            );
+            string(abi.encodePacked(namePrefix, IPerpdexMarket(marketArg).symbol(), IERC20Metadata(assetVar).symbol()));
     }
 
-    function _getERC20Symbol(address marketArg, string memory symbolPrefix) private view returns (string memory) {
+    function _getERC20Symbol(
+        address marketArg,
+        address assetVar,
+        string memory symbolPrefix
+    ) private view returns (string memory) {
         return
             string(
-                abi.encodePacked(
-                    symbolPrefix,
-                    IPerpdexMarket(marketArg).symbol(),
-                    IERC20Metadata(IPerpdexExchange(IPerpdexMarket(marketArg).exchange()).settlementToken()).symbol()
-                )
+                abi.encodePacked(symbolPrefix, IPerpdexMarket(marketArg).symbol(), IERC20Metadata(assetVar).symbol())
             );
     }
 

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -233,17 +233,12 @@ abstract contract PerpdexTokenBase is IERC4626, ReentrancyGuard, ERC20 {
     function _depositToPerpdex(uint256 amount) internal {
         if (weth == address(0)) {
             IERC20(asset).approve(exchange, type(uint256).max);
-        } else {
-            IWETH9(weth).withdraw(amount);
         }
         IPerpdexExchange(exchange).deposit(amount);
     }
 
     function _withdrawFromPerpdex(uint256 amount) internal {
         IPerpdexExchange(exchange).withdraw(_convertToPerpdexDecimals(amount));
-        if (weth != address(0)) {
-            IWETH9(weth).deposit{ value: amount }();
-        }
     }
 
     function _transferAssetTo(address to, uint256 amount) internal {

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -62,6 +62,8 @@ abstract contract PerpdexTokenBase is IERC4626, ReentrancyGuard, ERC20 {
         exchange = exchangeVar;
     }
 
+    receive() external payable {}
+
     // make ERC20 external functions non reentrant
 
     function transfer(address recipient, uint256 amount) public override nonReentrant returns (bool) {

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -182,7 +182,7 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
 
     function _depositToPerpdex(uint256 amount) internal {
         IERC20(asset).approve(exchange, type(uint256).max);
-        IPerpdexExchange(exchange).deposit(_convertToPerpdexDecimals(amount));
+        IPerpdexExchange(exchange).deposit(amount);
     }
 
     function _assetSafeTransfer(address to, uint256 amount) internal {

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -47,8 +47,7 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
         if (supply == 0) {
             return FullMath.mulDiv(shares, 10**IERC20Metadata(asset).decimals(), 10**decimals());
         }
-        assets = FullMath.mulDiv(shares, totalAssets(), supply);
-        assets = _convertToAssetDecimals(assets);
+        return FullMath.mulDiv(shares, totalAssets(), supply);
     }
 
     function _convertToPerpdexDecimals(uint256 amount) internal view returns (uint256 assets) {

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -114,7 +114,7 @@ abstract contract PerpdexTokenBase is IERC4626, ReentrancyGuard, ERC20 {
             return
                 FullMath.mulDiv(
                     _convertToAssetDecimals(shares),
-                    IPerpdexMarket(market).getMarkPriceX96(),
+                    IPerpdexMarket(market).getShareMarkPriceX96(),
                     FixedPoint96.Q96
                 );
         }

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -47,7 +47,8 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
         if (supply == 0) {
             return FullMath.mulDiv(shares, 10**IERC20Metadata(asset).decimals(), 10**decimals());
         }
-        return FullMath.mulDiv(shares, totalAssets(), supply);
+        assets = FullMath.mulDiv(shares, totalAssets(), supply);
+        assets = _convertToAssetDecimals(assets);
     }
 
     function _convertToPerpdexDecimals(uint256 amount) internal view returns (uint256 assets) {

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -31,7 +31,7 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
 
     function totalAssets() public view override returns (uint256 totalManagedAssets) {
         int256 value = IPerpdexExchange(exchange).getTotalAccountValue(address(this));
-        totalManagedAssets = value < 0 ? 0 : uint256(value);
+        totalManagedAssets = value < 0 ? 0 : _convertToAssetDecimals(uint256(value));
     }
 
     function convertToShares(uint256 assets) public view override returns (uint256 shares) {
@@ -39,7 +39,7 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
         if (supply == 0) {
             return FullMath.mulDiv(assets, 10**decimals(), 10**IERC20Metadata(asset).decimals());
         }
-        return FullMath.mulDiv(_convertToPerpdexDecimals(assets), supply, totalAssets());
+        return FullMath.mulDiv(assets, supply, totalAssets());
     }
 
     function convertToAssets(uint256 shares) public view override returns (uint256 assets) {

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -244,8 +244,10 @@ abstract contract PerpdexTokenBase is IERC4626, ReentrancyGuard, ERC20 {
     function _depositToPerpdex(uint256 amount) internal {
         if (weth == address(0)) {
             IERC20(asset).approve(exchange, type(uint256).max);
+            IPerpdexExchange(exchange).deposit(amount);
+        } else {
+            IPerpdexExchange(exchange).deposit{ value: amount }(0);
         }
-        IPerpdexExchange(exchange).deposit(amount);
     }
 
     function _withdrawFromPerpdex(uint256 amount) internal {

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -39,7 +39,7 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
         if (supply == 0) {
             return FullMath.mulDiv(assets, 10**decimals(), 10**IERC20Metadata(asset).decimals());
         }
-        return FullMath.mulDiv(assets, supply, totalAssets());
+        return FullMath.mulDiv(_convertToPerpdexDecimals(assets), supply, totalAssets());
     }
 
     function convertToAssets(uint256 shares) public view override returns (uint256 assets) {

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.7.6;
 pragma abicoder v2;
 
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
@@ -9,25 +10,74 @@ import { SafeCast } from "@openzeppelin/contracts/utils/SafeCast.sol";
 import { FullMath } from "@uniswap/v3-core/contracts/libraries/FullMath.sol";
 import { IPerpdexExchange } from "../deps/perpdex-contract/contracts/interface/IPerpdexExchange.sol";
 import { IPerpdexMarket } from "../deps/perpdex-contract/contracts/interface/IPerpdexMarket.sol";
+import { IWETH9 } from "../deps/perpdex-contract/contracts/interface/external/IWETH9.sol";
 import { IERC4626 } from "./interface/IERC4626.sol";
 import { IERC20Metadata } from "./interface/IERC20Metadata.sol";
 
-abstract contract PerpdexTokenBase is IERC4626, ERC20 {
+abstract contract PerpdexTokenBase is IERC4626, ReentrancyGuard, ERC20 {
     using SafeCast for int256;
 
     address public immutable override asset;
     address public immutable market;
     address public immutable exchange;
+    address public immutable weth;
+
+    modifier onlyWeth() {
+        require(weth != address(0), "PTB_OW: weth is not available");
+        _;
+    }
 
     constructor(
         address marketArg,
         string memory namePrefix,
-        string memory symbolPrefix
+        string memory symbolPrefix,
+        address wethArg
     ) ERC20(_getERC20Name(marketArg, namePrefix), _getERC20Symbol(marketArg, symbolPrefix)) {
+        address exchangeVar = IPerpdexMarket(marketArg).exchange();
+        address settlementToken = IPerpdexExchange(exchangeVar).settlementToken();
+        address assetVar;
+
+        if (settlementToken == address(0)) {
+            require(wethArg != address(0), "PTB_C: weth is required");
+            assetVar = wethArg;
+        } else {
+            require(wethArg == address(0), "PTB_C: weth can not be used");
+            assetVar = settlementToken;
+        }
+
+        asset = assetVar;
         market = marketArg;
-        exchange = IPerpdexMarket(marketArg).exchange();
-        asset = IPerpdexExchange(IPerpdexMarket(marketArg).exchange()).settlementToken();
+        weth = wethArg;
+        exchange = exchangeVar;
     }
+
+    // make ERC20 external functions non reentrant
+
+    function transfer(address recipient, uint256 amount) public override nonReentrant returns (bool) {
+        return ERC20.transfer(recipient, amount);
+    }
+
+    function approve(address spender, uint256 amount) public override nonReentrant returns (bool) {
+        return ERC20.approve(spender, amount);
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public override nonReentrant returns (bool) {
+        return ERC20.transferFrom(sender, recipient, amount);
+    }
+
+    function increaseAllowance(address spender, uint256 addedValue) public override nonReentrant returns (bool) {
+        return ERC20.increaseAllowance(spender, addedValue);
+    }
+
+    function decreaseAllowance(address spender, uint256 subtractedValue) public override nonReentrant returns (bool) {
+        return ERC20.decreaseAllowance(spender, subtractedValue);
+    }
+
+    // ERC4626
 
     function totalAssets() public view override returns (uint256 totalManagedAssets) {
         int256 value = IPerpdexExchange(exchange).getTotalAccountValue(address(this));
@@ -181,20 +231,35 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
     }
 
     function _depositToPerpdex(uint256 amount) internal {
-        IERC20(asset).approve(exchange, type(uint256).max);
+        if (weth == address(0)) {
+            IERC20(asset).approve(exchange, type(uint256).max);
+        } else {
+            IWETH9(weth).withdraw(amount);
+        }
         IPerpdexExchange(exchange).deposit(amount);
     }
 
-    function _assetSafeTransfer(address to, uint256 amount) internal {
+    function _withdrawFromPerpdex(uint256 amount) internal {
+        IPerpdexExchange(exchange).withdraw(_convertToPerpdexDecimals(amount));
+        if (weth != address(0)) {
+            IWETH9(weth).deposit{ value: amount }();
+        }
+    }
+
+    function _transferAssetTo(address to, uint256 amount) internal {
+        if (weth != address(0)) {
+            IWETH9(weth).deposit{ value: amount }();
+        }
         SafeERC20.safeTransfer(IERC20(asset), to, amount);
     }
 
-    function _assetSafeTransferFrom(
-        address from,
-        address to,
-        uint256 amount
-    ) internal {
+    function _transferAssetFromSender(uint256 amount) internal {
+        address from = msg.sender;
+        address to = address(this);
         SafeERC20.safeTransferFrom(IERC20(asset), from, to, amount);
+        if (weth != address(0)) {
+            IWETH9(weth).withdraw(amount);
+        }
     }
 
     function _getERC20Name(address marketArg, string memory namePrefix) private view returns (string memory) {

--- a/contracts/PerpdexTokenBase.sol
+++ b/contracts/PerpdexTokenBase.sol
@@ -53,25 +53,25 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
     }
 
     function maxDeposit(address) public view override returns (uint256 maxAssets) {
-        return _maxOpenPosition(false, true);
+        return _maxTrade(false, true);
     }
 
     function maxMint(address) public view override returns (uint256 maxShares) {
-        return _maxOpenPosition(false, false);
+        return _maxTrade(false, false);
     }
 
     function maxWithdraw(address owner) public view override returns (uint256 maxAssets) {
-        return PerpdexTokenMath.minUint256(convertToAssets(balanceOf(owner)), _maxOpenPosition(true, false));
+        return PerpdexTokenMath.minUint256(convertToAssets(balanceOf(owner)), _maxTrade(true, false));
     }
 
     function maxRedeem(address owner) public view override returns (uint256 maxShares) {
-        return PerpdexTokenMath.minUint256(balanceOf(owner), _maxOpenPosition(true, true));
+        return PerpdexTokenMath.minUint256(balanceOf(owner), _maxTrade(true, true));
     }
 
-    function _maxOpenPosition(bool isBaseToQuote, bool isExactInput) internal view returns (uint256 maxAmount) {
+    function _maxTrade(bool isBaseToQuote, bool isExactInput) internal view returns (uint256 maxAmount) {
         return
-            IPerpdexExchange(exchange).maxOpenPosition(
-                IPerpdexExchange.MaxOpenPositionParams({
+            IPerpdexExchange(exchange).maxTrade(
+                IPerpdexExchange.MaxTradeParams({
                     trader: address(this),
                     market: market,
                     caller: address(this),
@@ -81,14 +81,14 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
             );
     }
 
-    function _previewOpenPosition(
+    function _previewTrade(
         bool isBaseToQuote,
         bool isExactInput,
         uint256 amount
     ) internal view returns (uint256 oppositeAmount) {
         return
-            IPerpdexExchange(exchange).previewOpenPosition(
-                IPerpdexExchange.PreviewOpenPositionParams({
+            IPerpdexExchange(exchange).previewTrade(
+                IPerpdexExchange.PreviewTradeParams({
                     trader: address(this),
                     market: market,
                     caller: address(this),
@@ -100,14 +100,14 @@ abstract contract PerpdexTokenBase is IERC4626, ERC20 {
             );
     }
 
-    function _openPosition(
+    function _trade(
         bool isBaseToQuote,
         bool isExactInput,
         uint256 amount
     ) internal returns (uint256 oppositeAmount) {
         return
-            IPerpdexExchange(exchange).openPosition(
-                IPerpdexExchange.OpenPositionParams({
+            IPerpdexExchange(exchange).trade(
+                IPerpdexExchange.TradeParams({
                     trader: address(this),
                     market: market,
                     isBaseToQuote: isBaseToQuote,

--- a/contracts/lib/PerpdexTokenMath.sol
+++ b/contracts/lib/PerpdexTokenMath.sol
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.7.6;
-pragma abicoder v2;
-
-library PerpdexTokenMath {
-    function minUint256(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a < b ? a : b;
-    }
-}

--- a/contracts/test/TestERC20.sol
+++ b/contracts/test/TestERC20.sol
@@ -32,5 +32,6 @@ contract TestERC20 is ERC20PresetMinterPauser {
 
     function withdraw(uint256 amount) external {
         _burn(msg.sender, amount);
+        msg.sender.transfer(amount);
     }
 }

--- a/contracts/test/TestERC20.sol
+++ b/contracts/test/TestERC20.sol
@@ -23,4 +23,14 @@ contract TestERC20 is ERC20PresetMinterPauser {
     ) external {
         _approve(from, to, amount);
     }
+
+    // WETH interface
+
+    function deposit() external payable {
+        _mint(msg.sender, msg.value);
+    }
+
+    function withdraw(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
 }

--- a/contracts/test/TestPerpdexMarket.sol
+++ b/contracts/test/TestPerpdexMarket.sol
@@ -3,6 +3,7 @@ pragma solidity 0.7.6;
 pragma abicoder v2;
 
 import { PerpdexMarket } from "../../deps/perpdex-contract/contracts/PerpdexMarket.sol";
+import { MarketStructs } from "../../deps/perpdex-contract/contracts/lib/MarketStructs.sol";
 
 contract TestPerpdexMarket is PerpdexMarket {
     constructor(
@@ -11,4 +12,8 @@ contract TestPerpdexMarket is PerpdexMarket {
         address priceFeedBaseArg,
         address priceFeedQuoteArg
     ) PerpdexMarket(symbolArg, exchangeArg, priceFeedBaseArg, priceFeedQuoteArg) {}
+
+    function setPoolInfo(MarketStructs.PoolInfo memory value) external {
+        poolInfo = value;
+    }
 }

--- a/contracts/test/TestPerpdexTokenBase.sol
+++ b/contracts/test/TestPerpdexTokenBase.sol
@@ -9,8 +9,9 @@ contract TestPerpdexTokenBase is PerpdexTokenBase {
     constructor(
         address marketArg,
         string memory namePrefix,
-        string memory symbolPrefix
-    ) PerpdexTokenBase(marketArg, namePrefix, symbolPrefix) {}
+        string memory symbolPrefix,
+        address wethArg
+    ) PerpdexTokenBase(marketArg, namePrefix, symbolPrefix, wethArg) {}
 
     function previewDeposit(uint256 assets) external view override returns (uint256 shares) {}
 

--- a/contracts/test/TestPerpdexTokenBase.sol
+++ b/contracts/test/TestPerpdexTokenBase.sol
@@ -53,4 +53,8 @@ contract TestPerpdexTokenBase is PerpdexTokenBase {
     ) external {
         _spendAllowance(owner, spender, amount);
     }
+
+    function testMint(address receiver, uint256 shares) external {
+        _mint(receiver, shares);
+    }
 }

--- a/contracts/test/TestPerpdexTokenBase.sol
+++ b/contracts/test/TestPerpdexTokenBase.sol
@@ -11,7 +11,7 @@ contract TestPerpdexTokenBase is PerpdexTokenBase {
         string memory namePrefix,
         string memory symbolPrefix,
         address wethArg
-    ) PerpdexTokenBase(marketArg, namePrefix, symbolPrefix, wethArg) {}
+    ) PerpdexTokenBase(marketArg, namePrefix, symbolPrefix, "ETH", wethArg) {}
 
     function previewDeposit(uint256 assets) external view override returns (uint256 shares) {}
 

--- a/contracts/test/TestPerpdexTokenBase.sol
+++ b/contracts/test/TestPerpdexTokenBase.sol
@@ -20,6 +20,14 @@ contract TestPerpdexTokenBase is PerpdexTokenBase {
 
     function previewRedeem(uint256 shares) external view override returns (uint256 assets) {}
 
+    function maxDeposit(address receiver) external view override returns (uint256 maxAssets) {}
+
+    function maxMint(address receiver) external view override returns (uint256 maxShares) {}
+
+    function maxWithdraw(address owner) external view override returns (uint256 maxAssets) {}
+
+    function maxRedeem(address owner) external view override returns (uint256 maxShares) {}
+
     function mint(uint256 shares, address receiver) external override returns (uint256 assets) {}
 
     function deposit(uint256 assets, address receiver) external override returns (uint256 shares) {}

--- a/test/longToken/base.test.ts
+++ b/test/longToken/base.test.ts
@@ -110,7 +110,7 @@ describe("PerpdexLongToken base", async () => {
             },
         ].forEach(test => {
             it(test.title, async () => {
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
                 // alice deposits
                 var depositAssets = parseAssets(test.depositAssets)
@@ -155,7 +155,7 @@ describe("PerpdexLongToken base", async () => {
             },
         ].forEach(test => {
             it(test.title, async () => {
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
                 // alice deposits
                 var depositAssets = parseAssets(test.depositAssets)

--- a/test/longToken/base.test.ts
+++ b/test/longToken/base.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 import { expect } from "chai"
-import { Wallet } from "ethers"
+import { BigNumber, Wallet } from "ethers"
 import { parseUnits } from "ethers/lib/utils"
 import { ethers, waffle } from "hardhat"
 import { PerpdexLongToken, TestERC20, TestPerpdexExchange, TestPerpdexMarket } from "../../typechain"
@@ -20,6 +20,8 @@ describe("PerpdexLongToken base", async () => {
     let owner: Wallet
     let alice: Wallet
     let bob: Wallet
+
+    const Q96 = BigNumber.from(2).pow(96)
 
     beforeEach(async () => {
         fixture = await loadFixture(createPerpdexExchangeFixture())
@@ -108,6 +110,17 @@ describe("PerpdexLongToken base", async () => {
                 expected: "5",
             },
             {
+                title: "totalSupply == 0 and pool has liquidity and base rebased",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                    baseBalancePerShareX96: Q96.mul(2),
+                },
+                depositAssets: "0",
+                convertAssets: "5",
+                expected: "5",
+            },
+            {
                 title: "totalSupply == 0 and pool is unbalanced",
                 pool: {
                     base: "10000",
@@ -129,7 +142,12 @@ describe("PerpdexLongToken base", async () => {
             },
         ].forEach(test => {
             it(test.title, async () => {
-                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+                await initPool(
+                    fixture,
+                    parseShares(test.pool.base),
+                    parseShares(test.pool.quote),
+                    test.pool.baseBalancePerShareX96,
+                )
 
                 // alice deposits
                 var depositAssets = parseAssets(test.depositAssets)
@@ -176,6 +194,17 @@ describe("PerpdexLongToken base", async () => {
                 expected: "5",
             },
             {
+                title: "totalSupply == 0 and pool has liquidity and base rebased",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                    baseBalancePerShareX96: Q96.mul(2),
+                },
+                depositAssets: "0",
+                convertShares: "5",
+                expected: "5",
+            },
+            {
                 title: "totalSupply == 0 and pool is unbalanced",
                 pool: {
                     base: "10000",
@@ -197,7 +226,12 @@ describe("PerpdexLongToken base", async () => {
             },
         ].forEach(test => {
             it(test.title, async () => {
-                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+                await initPool(
+                    fixture,
+                    parseShares(test.pool.base),
+                    parseShares(test.pool.quote),
+                    test.pool.baseBalancePerShareX96,
+                )
 
                 // alice deposits
                 var depositAssets = parseAssets(test.depositAssets)

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -28,9 +28,16 @@ describe("PerpdexLongToken decimals", async () => {
         }
     }
 
-    async function setupEnvironment(assetDecimals: number, quoteDecimals: number, poolBase: string, poolQuote: string) {
+    async function setupEnvironment(
+        settlementToken: string,
+        assetDecimals: number,
+        quoteDecimals: number,
+        poolBase: string,
+        poolQuote: string,
+    ) {
         fixture = await loadFixture(
             createPerpdexExchangeFixture({
+                settlementToken: settlementToken,
                 wethDecimals: assetDecimals,
             }),
         )
@@ -52,7 +59,7 @@ describe("PerpdexLongToken decimals", async () => {
         await initPool(fixture, parseUnits(poolBase, quoteDecimals), parseUnits(poolQuote, quoteDecimals))
     }
 
-    // alice deposit to perpdex
+    // alice deposit to perpdex by wETH
     async function depositByWeth(test, deposit) {
         // mint balance
         await weth.connect(owner).mint(alice.address, deposit.assets)
@@ -65,13 +72,25 @@ describe("PerpdexLongToken decimals", async () => {
         await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
     }
 
+    // alice deposit to perpdex
+    async function depositByETH(test, deposit) {
+        // deposit
+        var receiver = toWallet(deposit.receiver)
+        await longToken.connect(alice).depositETH(receiver.address, { value: deposit.assets })
+
+        // change market allowance
+        await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
+    }
+
     function toNumber(x: BigNumber, decimals: number) {
         return x.div(BigNumber.from(10).pow(decimals)).toNumber()
     }
 
     ;[
+        /*
         {
-            assetDecimalsList: [6, 18],
+            settlementToken: "weth",
+            assetDecimals: 6,
             quoteDecimals: 18,
             pool: {
                 base: "10000",
@@ -79,219 +98,278 @@ describe("PerpdexLongToken decimals", async () => {
             },
             isMarketAllowed: true,
 
-            deposits: [
-                {
-                    depositFunc: depositByWeth,
-                    assets: parseUnits("100", 6),
-                    receiver: "alice",
-                    expects: {
-                        balanceOf: {
-                            owner: "alice",
-                        },
-
-                        totalSupply: {},
-                        totalAssets: {},
-
-                        convertToShares: {
-                            assets: parseUnits("50", 6),
-                        },
-
-                        convertToAssets: {
-                            shares: parseUnits("50", 18),
-                        },
-
-                        previewDeposit: {
-                            assets: parseUnits("50", 6),
-                        },
-
-                        previewMint: {
-                            shares: parseUnits("49", 18),
-                        },
-
-                        previewWithdraw: {
-                            assets: parseUnits("50", 6),
-                        },
-
-                        previewRedeem: {
-                            shares: parseUnits("49", 18),
-                        },
-
-                        maxDeposit: {},
-
-                        maxMint: {},
-
-                        maxWithdraw: {},
-
-                        maxRedeem: {},
+            deposit: {
+                depositFunc: depositByWeth,
+                assets: parseUnits("100", 6),
+                receiver: "alice",
+                expects: {
+                    balanceOf: {
+                        owner: "alice",
                     },
+
+                    totalSupply: {},
+                    totalAssets: {},
+
+                    convertToShares: {
+                        assets: parseUnits("50", 6),
+                    },
+
+                    convertToAssets: {
+                        shares: parseUnits("50", 18),
+                    },
+
+                    previewDeposit: {
+                        assets: parseUnits("50", 6),
+                    },
+
+                    previewMint: {
+                        shares: parseUnits("49", 18),
+                    },
+
+                    previewWithdraw: {
+                        assets: parseUnits("50", 6),
+                    },
+
+                    previewRedeem: {
+                        shares: parseUnits("49", 18),
+                    },
+
+                    maxDeposit: {},
+
+                    maxMint: {},
+
+                    maxWithdraw: {},
+
+                    maxRedeem: {},
                 },
-            ],
+            },
+        },
+        */
+        {
+            settlementToken: "ETH",
+            assetDecimals: 18,
+            quoteDecimals: 18,
+            pool: {
+                base: "10000",
+                quote: "40000",
+            },
+            isMarketAllowed: true,
+
+            deposit: {
+                depositFunc: depositByETH,
+                assets: parseUnits("100", 18),
+                receiver: "alice",
+                expects: {
+                    balanceOf: {
+                        owner: "alice",
+                    },
+
+                    totalSupply: {},
+                    totalAssets: {},
+
+                    convertToShares: {
+                        assets: parseUnits("50", 18),
+                    },
+
+                    convertToAssets: {
+                        shares: parseUnits("50", 18),
+                    },
+
+                    previewDeposit: {
+                        assets: parseUnits("50", 18),
+                    },
+
+                    previewMint: {
+                        shares: parseUnits("49", 18),
+                    },
+
+                    previewWithdraw: {
+                        assets: parseUnits("50", 18),
+                    },
+
+                    previewRedeem: {
+                        shares: parseUnits("49", 18),
+                    },
+
+                    maxDeposit: {},
+
+                    maxMint: {},
+
+                    maxWithdraw: {},
+
+                    maxRedeem: {},
+                },
+            },
         },
     ].forEach(test => {
-        test.assetDecimalsList.forEach(assetDecimals => {
-            describe(`assetDecimals == ${assetDecimals}\t`, async () => {
-                beforeEach(async () => {
-                    await setupEnvironment(assetDecimals, test.quoteDecimals, test.pool.base, test.pool.quote)
-                })
-
-                test.deposits.forEach(deposit => {
-                    it("balanceOf", async () => {
-                        await deposit.depositFunc(test, deposit)
-                        var balanceOfOwner = toWallet(deposit.expects.balanceOf.owner)
-
-                        var refVal = await longToken.convertToShares(deposit.assets)
-                        var refNum = toNumber(refVal, test.quoteDecimals)
-                        var num = toNumber(await longToken.balanceOf(balanceOfOwner.address), test.quoteDecimals)
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-                    })
-
-                    it("totalSupply", async () => {
-                        await deposit.depositFunc(test, deposit)
-
-                        var refVal = await longToken.convertToShares(deposit.assets)
-                        var refNum = toNumber(refVal, test.quoteDecimals)
-                        var num = toNumber(await longToken.totalSupply(), test.quoteDecimals)
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-                    })
-
-                    it("totalAssets", async () => {
-                        await deposit.depositFunc(test, deposit)
-                        var refNum = toNumber(deposit.assets, assetDecimals)
-                        var num = toNumber(await longToken.totalAssets(), assetDecimals)
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-                    })
-
-                    it("convertToShares", async () => {
-                        var markSharePriceEst = Number(test.pool.base) / Number(test.pool.quote)
-
-                        var argVal = deposit.expects.convertToShares.assets
-                        // quote -> base
-                        var refNum = toNumber(argVal, assetDecimals) * markSharePriceEst
-
-                        // total supply == 0
-                        var val = await longToken.convertToShares(argVal)
-                        var num = toNumber(val, test.quoteDecimals)
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-
-                        await deposit.depositFunc(test, deposit)
-
-                        // total supply > 0
-                        var val = await longToken.convertToShares(argVal)
-                        var num = toNumber(val, test.quoteDecimals)
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-                    })
-
-                    it("convertToAssets", async () => {
-                        var markPriceEst = Number(test.pool.quote) / Number(test.pool.base)
-
-                        var argVal = deposit.expects.convertToAssets.shares
-                        // base -> quote
-                        var refNum = toNumber(argVal, test.quoteDecimals) * markPriceEst
-
-                        // total supply == 0
-                        var val = await longToken.convertToAssets(argVal)
-                        var num = toNumber(val, assetDecimals)
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-
-                        await deposit.depositFunc(test, deposit)
-
-                        // total supply > 0
-                        var val = await longToken.convertToAssets(argVal)
-                        var num = toNumber(val, assetDecimals)
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-                    })
-
-                    it("previewDeposit", async () => {
-                        await deposit.depositFunc(test, deposit)
-                        var argVal = deposit.expects.previewDeposit.assets
-                        var refVal = await longToken.convertToShares(argVal)
-                        var val = await longToken.previewDeposit(argVal)
-
-                        var refNum = toNumber(refVal, test.quoteDecimals)
-                        var num = toNumber(val, test.quoteDecimals)
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-                    })
-
-                    it("previewMint", async () => {
-                        await deposit.depositFunc(test, deposit)
-                        var argVal = deposit.expects.previewMint.shares
-                        var refVal = await longToken.convertToAssets(argVal)
-                        var val = await longToken.previewMint(argVal)
-
-                        var refNum = toNumber(refVal, assetDecimals)
-                        var num = toNumber(val, assetDecimals)
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-                    })
-
-                    it("previewWithdraw", async () => {
-                        await deposit.depositFunc(test, deposit)
-                        var argVal = deposit.expects.previewWithdraw.assets
-                        var refVal = await longToken.convertToShares(argVal)
-                        var val = await longToken.previewWithdraw(argVal)
-
-                        var refNum = toNumber(refVal, test.quoteDecimals)
-                        var num = toNumber(val, test.quoteDecimals)
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-                    })
-
-                    it("previewRedeem", async () => {
-                        await deposit.depositFunc(test, deposit)
-                        var argVal = deposit.expects.previewRedeem.shares
-                        var refVal = await longToken.convertToAssets(argVal)
-                        var val = await longToken.previewRedeem(argVal)
-
-                        var refNum = toNumber(refVal, assetDecimals)
-                        var num = toNumber(val, assetDecimals)
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-                    })
-
-                    it("maxDeposit", async () => {
-                        await deposit.depositFunc(test, deposit)
-                        var poolInfo = await market.poolInfo()
-                        var [refBaseVal, _] = await market.getLiquidityValue(poolInfo.totalLiquidity)
-                        var val = await longToken.maxDeposit(alice.address)
-
-                        var refNum = toNumber(refBaseVal, test.quoteDecimals) // pool base decimals == pool quote decimals
-                        var num = toNumber(val, assetDecimals)
-
-                        expect(num).to.within(refNum * 0.01, refNum * 0.05)
-                    })
-
-                    it("maxMint", async () => {
-                        await deposit.depositFunc(test, deposit)
-                        var poolInfo = await market.poolInfo()
-                        var [_, refQuoteVal] = await market.getLiquidityValue(poolInfo.totalLiquidity)
-                        var val = await longToken.maxMint(alice.address)
-
-                        var refNum = toNumber(refQuoteVal, test.quoteDecimals)
-                        var num = toNumber(val, test.quoteDecimals)
-
-                        expect(num).to.within(refNum * 0.01, refNum * 0.05)
-                    })
-
-                    it("maxWithdraw", async () => {
-                        await deposit.depositFunc(test, deposit)
-                        var refVal = await longToken.totalAssets()
-                        var val = await longToken.maxWithdraw(alice.address)
-
-                        var refNum = toNumber(refVal, assetDecimals)
-                        var num = toNumber(val, assetDecimals)
-
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-                    })
-
-                    it("maxRedeem", async () => {
-                        await deposit.depositFunc(test, deposit)
-                        var refVal = await longToken.totalSupply()
-                        var val = await longToken.maxRedeem(alice.address)
-
-                        var refNum = toNumber(refVal, test.quoteDecimals)
-                        var num = toNumber(val, test.quoteDecimals)
-
-                        expect(num).to.within(refNum * 0.95, refNum * 1.05)
-                    })
-                })
+        describe(`assetDecimals == ${test.assetDecimals}\t`, async () => {
+            beforeEach(async () => {
+                await setupEnvironment(
+                    test.settlementToken,
+                    test.assetDecimals,
+                    test.quoteDecimals,
+                    test.pool.base,
+                    test.pool.quote,
+                )
             })
+
+            it("balanceOf", async () => {
+                await test.deposit.depositFunc(test, test.deposit)
+                var balanceOfOwner = toWallet(test.deposit.expects.balanceOf.owner)
+
+                var refVal = await longToken.convertToShares(test.deposit.assets)
+                var refNum = toNumber(refVal, test.quoteDecimals)
+                var num = toNumber(await longToken.balanceOf(balanceOfOwner.address), test.quoteDecimals)
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+            })
+
+            it("totalSupply", async () => {
+                await test.deposit.depositFunc(test, test.deposit)
+
+                var refVal = await longToken.convertToShares(test.deposit.assets)
+                var refNum = toNumber(refVal, test.quoteDecimals)
+                var num = toNumber(await longToken.totalSupply(), test.quoteDecimals)
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+            })
+
+            it("totalAssets", async () => {
+                await test.deposit.depositFunc(test, test.deposit)
+                var refNum = toNumber(test.deposit.assets, test.assetDecimals)
+                var num = toNumber(await longToken.totalAssets(), test.assetDecimals)
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+            })
+
+            /*
+            it("convertToShares", async () => {
+                var markSharePriceEst = Number(test.pool.base) / Number(test.pool.quote)
+
+                var argVal = test.deposit.expects.convertToShares.assets
+                // quote -> base
+                var refNum = toNumber(argVal, test.assetDecimals) * markSharePriceEst
+
+                // total supply == 0
+                var val = await longToken.convertToShares(argVal)
+                var num = toNumber(val, test.quoteDecimals)
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+
+                await test.deposit.depositFunc(test, test.deposit)
+
+                // total supply > 0
+                var val = await longToken.convertToShares(argVal)
+                var num = toNumber(val, test.quoteDecimals)
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+            })
+
+            it("convertToAssets", async () => {
+                var markPriceEst = Number(test.pool.quote) / Number(test.pool.base)
+
+                var argVal = test.deposit.expects.convertToAssets.shares
+                // base -> quote
+                var refNum = toNumber(argVal, test.quoteDecimals) * markPriceEst
+
+                // total supply == 0
+                var val = await longToken.convertToAssets(argVal)
+                var num = toNumber(val, test.assetDecimals)
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+
+                await test.deposit.depositFunc(test, test.deposit)
+
+                // total supply > 0
+                var val = await longToken.convertToAssets(argVal)
+                var num = toNumber(val, test.assetDecimals)
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+            })
+
+            it("previewDeposit", async () => {
+                await test.deposit.depositFunc(test, test.deposit)
+                var argVal = test.deposit.expects.previewDeposit.assets
+                var refVal = await longToken.convertToShares(argVal)
+                var val = await longToken.previewDeposit(argVal)
+
+                var refNum = toNumber(refVal, test.quoteDecimals)
+                var num = toNumber(val, test.quoteDecimals)
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+            })
+
+            it("previewMint", async () => {
+                await test.deposit.depositFunc(test, test.deposit)
+                var argVal = test.deposit.expects.previewMint.shares
+                var refVal = await longToken.convertToAssets(argVal)
+                var val = await longToken.previewMint(argVal)
+
+                var refNum = toNumber(refVal, test.assetDecimals)
+                var num = toNumber(val, test.assetDecimals)
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+            })
+
+            it("previewWithdraw", async () => {
+                await test.deposit.depositFunc(test, test.deposit)
+                var argVal = test.deposit.expects.previewWithdraw.assets
+                var refVal = await longToken.convertToShares(argVal)
+                var val = await longToken.previewWithdraw(argVal)
+
+                var refNum = toNumber(refVal, test.quoteDecimals)
+                var num = toNumber(val, test.quoteDecimals)
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+            })
+
+            it("previewRedeem", async () => {
+                await test.deposit.depositFunc(test, test.deposit)
+                var argVal = test.deposit.expects.previewRedeem.shares
+                var refVal = await longToken.convertToAssets(argVal)
+                var val = await longToken.previewRedeem(argVal)
+
+                var refNum = toNumber(refVal, test.assetDecimals)
+                var num = toNumber(val, test.assetDecimals)
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+            })
+
+            it("maxDeposit", async () => {
+                await test.deposit.depositFunc(test, test.deposit)
+                var poolInfo = await market.poolInfo()
+                var [refBaseVal, _] = await market.getLiquidityValue(poolInfo.totalLiquidity)
+                var val = await longToken.maxDeposit(alice.address)
+
+                var refNum = toNumber(refBaseVal, test.quoteDecimals) // pool base decimals == pool quote decimals
+                var num = toNumber(val, test.assetDecimals)
+
+                expect(num).to.within(refNum * 0.01, refNum * 0.05)
+            })
+
+            it("maxMint", async () => {
+                await test.deposit.depositFunc(test, test.deposit)
+                var poolInfo = await market.poolInfo()
+                var [_, refQuoteVal] = await market.getLiquidityValue(poolInfo.totalLiquidity)
+                var val = await longToken.maxMint(alice.address)
+
+                var refNum = toNumber(refQuoteVal, test.quoteDecimals)
+                var num = toNumber(val, test.quoteDecimals)
+
+                expect(num).to.within(refNum * 0.01, refNum * 0.05)
+            })
+
+            it("maxWithdraw", async () => {
+                await test.deposit.depositFunc(test, test.deposit)
+                var refVal = await longToken.totalAssets()
+                var val = await longToken.maxWithdraw(alice.address)
+
+                var refNum = toNumber(refVal, test.assetDecimals)
+                var num = toNumber(val, test.assetDecimals)
+
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+            })
+
+            it("maxRedeem", async () => {
+                await test.deposit.depositFunc(test, test.deposit)
+                var refVal = await longToken.totalSupply()
+                var val = await longToken.maxRedeem(alice.address)
+
+                var refNum = toNumber(refVal, test.quoteDecimals)
+                var num = toNumber(val, test.quoteDecimals)
+
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
+            })
+            */
         })
     })
 })

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -84,8 +84,12 @@ describe("PerpdexLongToken base decimals", async () => {
 
             previewDeposit: {
                 assets: parseUnits("50", 6),
-                receiver: "alice",
-                expected: parseUnits("50", 18),
+                expected: parseUnits("48.773350241428083695", 18),
+            },
+
+            previewMint: {
+                shares: parseUnits("48.773350241428083695", 18),
+                expected: parseUnits("50", 6),
             },
         },
     ].forEach(test => {
@@ -128,6 +132,14 @@ describe("PerpdexLongToken base decimals", async () => {
                 expect(await longToken.convertToAssets(test.convertToAssets.shares)).to.eq(
                     test.convertToAssets.expected,
                 )
+            })
+
+            it("previewDeposit", async () => {
+                expect(await longToken.previewDeposit(test.previewDeposit.assets)).to.eq(test.previewDeposit.expected)
+            })
+
+            it("previewMint", async () => {
+                expect(await longToken.previewMint(test.previewMint.shares)).to.eq(test.previewMint.expected)
             })
         })
     })

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -66,49 +66,66 @@ describe("PerpdexLongToken base decimals", async () => {
             deposit: {
                 assets: parseUnits("100", 6),
                 receiver: "alice",
-            },
+                expects: {
+                    balanceOf: {
+                        owner: "alice",
+                        expected: parseUnits("99.009900990099009900", 18),
+                    },
 
-            balanceOf: {
-                owner: "alice",
-                expected: parseUnits("99.009900990099009900", 18),
-            },
+                    totalSupply: {
+                        expected: parseUnits("99.009900990099009900", 18),
+                    },
 
-            totalSupply: {
-                expected: parseUnits("99.009900990099009900", 18),
-            },
+                    totalAssets: {
+                        expected: parseUnits("100.999999", 6),
+                    },
 
-            totalAssets: {
-                expected: parseUnits("100.999999", 6),
-            },
+                    convertToShares: {
+                        assets: parseUnits("50", 6),
+                        expected: parseUnits("49.014802955641123273", 18),
+                    },
 
-            convertToShares: {
-                assets: parseUnits("50", 6),
-                expected: parseUnits("49.014802955641123273", 18),
-            },
+                    convertToAssets: {
+                        shares: parseUnits("50", 18),
+                        expected: parseUnits("51.004999", 6),
+                    },
 
-            convertToAssets: {
-                shares: parseUnits("50", 18),
-                expected: parseUnits("51.004999", 6),
-            },
+                    previewDeposit: {
+                        assets: parseUnits("50", 6),
+                        expected: parseUnits("48.773350241428083695", 18),
+                    },
 
-            previewDeposit: {
-                assets: parseUnits("50", 6),
-                expected: parseUnits("48.773350241428083695", 18),
-            },
+                    previewMint: {
+                        shares: parseUnits("48.773350241428083695", 18),
+                        expected: parseUnits("50", 6),
+                    },
 
-            previewMint: {
-                shares: parseUnits("48.773350241428083695", 18),
-                expected: parseUnits("50", 6),
-            },
+                    previewWithdraw: {
+                        assets: parseUnits("50", 6),
+                        expected: parseUnits("49.258657209004482538", 18),
+                    },
 
-            previewWithdraw: {
-                assets: parseUnits("50", 6),
-                expected: parseUnits("49.258657209004482538", 18),
-            },
+                    previewRedeem: {
+                        shares: parseUnits("49.258657209004482538", 18),
+                        expected: parseUnits("50", 6),
+                    },
 
-            previewRedeem: {
-                shares: parseUnits("49.258657209004482538", 18),
-                expected: parseUnits("50", 6),
+                    maxDeposit: {
+                        expected: parseUnits("238.613139", 6),
+                    },
+
+                    maxMint: {
+                        expected: parseUnits("249.420273619194367053", 18),
+                    },
+
+                    maxWithdraw: {
+                        expected: parseUnits("257.211406", 6),
+                    },
+
+                    maxRedeem: {
+                        expected: parseUnits("99.009900990099009900", 18),
+                    },
+                },
             },
         },
     ].forEach(test => {
@@ -141,41 +158,63 @@ describe("PerpdexLongToken base decimals", async () => {
             })
 
             it("totalSupply", async () => {
-                expect(await longToken.totalSupply()).to.eq(test.totalSupply.expected)
+                expect(await longToken.totalSupply()).to.eq(test.deposit.expects.totalSupply.expected)
             })
 
             it("totalAssets", async () => {
-                expect(await longToken.totalAssets()).to.eq(test.totalAssets.expected)
+                expect(await longToken.totalAssets()).to.eq(test.deposit.expects.totalAssets.expected)
             })
 
             it("convertToShares", async () => {
-                expect(await longToken.convertToShares(test.convertToShares.assets)).to.eq(
-                    test.convertToShares.expected,
+                expect(await longToken.convertToShares(test.deposit.expects.convertToShares.assets)).to.eq(
+                    test.deposit.expects.convertToShares.expected,
                 )
             })
 
             it("convertToAssets", async () => {
-                expect(await longToken.convertToAssets(test.convertToAssets.shares)).to.eq(
-                    test.convertToAssets.expected,
+                expect(await longToken.convertToAssets(test.deposit.expects.convertToAssets.shares)).to.eq(
+                    test.deposit.expects.convertToAssets.expected,
                 )
             })
 
             it("previewDeposit", async () => {
-                expect(await longToken.previewDeposit(test.previewDeposit.assets)).to.eq(test.previewDeposit.expected)
+                expect(await longToken.previewDeposit(test.deposit.expects.previewDeposit.assets)).to.eq(
+                    test.deposit.expects.previewDeposit.expected,
+                )
             })
 
             it("previewMint", async () => {
-                expect(await longToken.previewMint(test.previewMint.shares)).to.eq(test.previewMint.expected)
+                expect(await longToken.previewMint(test.deposit.expects.previewMint.shares)).to.eq(
+                    test.deposit.expects.previewMint.expected,
+                )
             })
 
             it("previewWithdraw", async () => {
-                expect(await longToken.previewWithdraw(test.previewWithdraw.assets)).to.eq(
-                    test.previewWithdraw.expected,
+                expect(await longToken.previewWithdraw(test.deposit.expects.previewWithdraw.assets)).to.eq(
+                    test.deposit.expects.previewWithdraw.expected,
                 )
             })
 
             it("previewRedeem", async () => {
-                expect(await longToken.previewRedeem(test.previewRedeem.shares)).to.eq(test.previewRedeem.expected)
+                expect(await longToken.previewRedeem(test.deposit.expects.previewRedeem.shares)).to.eq(
+                    test.deposit.expects.previewRedeem.expected,
+                )
+            })
+
+            it("maxDeposit", async () => {
+                expect(await longToken.maxDeposit(alice.address)).to.eq(test.deposit.expects.maxDeposit.expected)
+            })
+
+            it("maxMint", async () => {
+                expect(await longToken.maxMint(alice.address)).to.eq(test.deposit.expects.maxMint.expected)
+            })
+
+            it("maxWithdraw", async () => {
+                expect(await longToken.maxWithdraw(alice.address)).to.eq(test.deposit.expects.maxWithdraw.expected)
+            })
+
+            it("maxRedeem", async () => {
+                expect(await longToken.maxRedeem(alice.address)).to.eq(test.deposit.expects.maxRedeem.expected)
             })
         })
     })

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -87,7 +87,6 @@ describe("PerpdexLongToken decimals", async () => {
     }
 
     ;[
-        /*
         {
             settlementToken: "weth",
             assetDecimals: 6,
@@ -144,7 +143,6 @@ describe("PerpdexLongToken decimals", async () => {
                 },
             },
         },
-        */
         {
             settlementToken: "ETH",
             assetDecimals: 18,
@@ -239,7 +237,6 @@ describe("PerpdexLongToken decimals", async () => {
                 expect(num).to.within(refNum * 0.95, refNum * 1.05)
             })
 
-            /*
             it("convertToShares", async () => {
                 var markSharePriceEst = Number(test.pool.base) / Number(test.pool.quote)
 
@@ -369,7 +366,6 @@ describe("PerpdexLongToken decimals", async () => {
 
                 expect(num).to.within(refNum * 0.95, refNum * 1.05)
             })
-            */
         })
     })
 })

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -41,12 +41,14 @@ describe("PerpdexLongToken base decimals", async () => {
         bob = fixture.bob
     })
 
+    // for assets
     function parseAssets(amount: string) {
         return parseUnits(amount, wethDecimals)
     }
 
-    function parseShares(amount: string) {
-        return parseUnits(amount, longTokenDecimals)
+    // for shares, perpdex base and quote
+    function parse18(amount: string) {
+        return parseUnits(amount, 18)
     }
 
     it("asset", async () => {
@@ -89,7 +91,6 @@ describe("PerpdexLongToken base decimals", async () => {
         beforeEach(async () => {
             // alice approve longToken of max assets
             await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
-            await weth.approveForce(longToken.address, exchange.address, ethers.constants.MaxUint256)
         })
         ;[
             {
@@ -114,7 +115,7 @@ describe("PerpdexLongToken base decimals", async () => {
             },
         ].forEach(test => {
             it(test.title, async () => {
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parse18(test.pool.base), parse18(test.pool.quote))
 
                 // alice deposits
                 var depositAssets = parseAssets(test.depositAssets)
@@ -122,10 +123,10 @@ describe("PerpdexLongToken base decimals", async () => {
                     await weth.connect(owner).mint(alice.address, depositAssets)
                     await longToken.connect(alice).deposit(depositAssets, alice.address)
                 }
+                console.log((await longToken.totalAssets()).toString())
+                console.log((await longToken.totalSupply()).toString())
 
-                expect(await longToken.convertToShares(parseAssets(test.convertAssets))).to.eq(
-                    parseShares(test.expected),
-                )
+                expect(await longToken.convertToShares(parseAssets(test.convertAssets))).to.eq(parse18(test.expected))
             })
         })
     })

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -12,14 +12,21 @@ describe("PerpdexLongToken base decimals", async () => {
     let fixture
 
     let longToken: PerpdexLongToken
-    let longTokenDecimals: number
     let market: TestPerpdexMarket
     let exchange: TestPerpdexExchange
     let weth: TestERC20
-    let wethDecimals: number
     let owner: Wallet
     let alice: Wallet
     let bob: Wallet
+
+    function toWallet(who: string) {
+        if (who === "alice") {
+            return alice
+        }
+        if (who === "bob") {
+            return bob
+        }
+    }
 
     async function before(decimals: number = 18) {
         fixture = await loadFixture(
@@ -29,12 +36,10 @@ describe("PerpdexLongToken base decimals", async () => {
         )
 
         longToken = fixture.perpdexLongToken
-        longTokenDecimals = await longToken.decimals()
         market = fixture.perpdexMarket
         exchange = fixture.perpdexExchange
 
         weth = fixture.weth
-        wethDecimals = await weth.decimals()
 
         owner = fixture.owner
         alice = fixture.alice
@@ -42,11 +47,6 @@ describe("PerpdexLongToken base decimals", async () => {
 
         // alice approve longToken of max assets
         await weth.connect(alice).approve(longToken.address, ethers.constants.MaxUint256)
-    }
-
-    // for assets
-    function parseAssets(amount: string) {
-        return parseUnits(amount, wethDecimals)
     }
 
     // for shares, perpdex base and quote
@@ -62,7 +62,16 @@ describe("PerpdexLongToken base decimals", async () => {
                 quote: "10000",
             },
             isMarketAllowed: true,
-            depositAssets: parseUnits("100", 6),
+
+            deposit: {
+                assets: parseUnits("100", 6),
+                receiver: "alice",
+            },
+
+            balanceOf: {
+                owner: "alice",
+                expected: parseUnits("99.009900990099009900", 18),
+            },
 
             totalSupply: {
                 expected: parseUnits("99.009900990099009900", 18),
@@ -110,10 +119,12 @@ describe("PerpdexLongToken base decimals", async () => {
                 await initPool(fixture, parse18(test.pool.base), parse18(test.pool.quote))
 
                 // alice deposit to perpdex
-                if (test.depositAssets.gt(0)) {
+                if (test.deposit !== void 0 && test.deposit.assets.gt(0)) {
                     // mint balance
-                    await weth.connect(owner).mint(alice.address, test.depositAssets)
-                    await longToken.connect(alice).deposit(test.depositAssets, alice.address)
+                    await weth.connect(owner).mint(alice.address, test.deposit.assets)
+                    // deposit
+                    var receiver = toWallet(test.deposit.receiver)
+                    await longToken.connect(alice).deposit(test.deposit.assets, receiver.address)
                 }
 
                 // change market allowance
@@ -122,6 +133,11 @@ describe("PerpdexLongToken base decimals", async () => {
 
             it("asset", async () => {
                 expect(await longToken.asset()).to.eq(await exchange.settlementToken())
+            })
+
+            it("balanceOf", async () => {
+                var owner_ = toWallet(test.balanceOf.owner)
+                expect(await longToken.balanceOf(owner_.address)).to.eq(test.balanceOf.expected)
             })
 
             it("totalSupply", async () => {

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -251,7 +251,6 @@ describe("PerpdexLongToken base decimals", async () => {
                 expect(num).to.within(refNum * 0.01, refNum * 0.05)
             })
 
-            /*
             it("maxWithdraw", async () => {
                 await doDeposit()
                 var refVal = await longToken.totalAssets()
@@ -263,6 +262,7 @@ describe("PerpdexLongToken base decimals", async () => {
                 expect(num).to.within(refNum * 0.95, refNum * 1.05)
             })
 
+            /*
             it("maxRedeem", async () => {
                 await doDeposit()
                 expect(await longToken.maxRedeem(alice.address)).to.eq(test.deposit.expects.maxRedeem.expected)

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -200,7 +200,7 @@ describe("PerpdexLongToken decimals", async () => {
             },
         },
     ].forEach(test => {
-        describe(`assetDecimals == ${test.assetDecimals}\t`, async () => {
+        describe(`settlementToken == ${test.settlementToken}, assetDecimals == ${test.assetDecimals}\t`, async () => {
             beforeEach(async () => {
                 await setupEnvironment(
                     test.settlementToken,

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -28,10 +28,10 @@ describe("PerpdexLongToken base decimals", async () => {
         }
     }
 
-    async function setupEnvironment(decimals: number, poolBase: string, poolQuote: string) {
+    async function setupEnvironment(assetDecimals: number, quoteDecimals: number, poolBase: string, poolQuote: string) {
         fixture = await loadFixture(
             createPerpdexExchangeFixture({
-                wethDecimals: decimals,
+                wethDecimals: assetDecimals,
             }),
         )
 
@@ -49,12 +49,7 @@ describe("PerpdexLongToken base decimals", async () => {
         await weth.connect(alice).approve(longToken.address, ethers.constants.MaxUint256)
 
         // init pool
-        await initPool(fixture, parse18(poolBase), parse18(poolQuote))
-    }
-
-    // for shares, perpdex base and quote
-    function parse18(amount: string) {
-        return parseUnits(amount, 18)
+        await initPool(fixture, parseUnits(poolBase, quoteDecimals), parseUnits(poolQuote, quoteDecimals))
     }
 
     ;[
@@ -123,7 +118,7 @@ describe("PerpdexLongToken base decimals", async () => {
     ].forEach(test => {
         describe(`assetDecimals == ${test.assetDecimals}\t`, async () => {
             beforeEach(async () => {
-                await setupEnvironment(test.assetDecimals, test.pool.base, test.pool.quote)
+                await setupEnvironment(test.assetDecimals, test.quoteDecimals, test.pool.base, test.pool.quote)
             })
 
             async function doDeposit() {

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -262,12 +262,16 @@ describe("PerpdexLongToken base decimals", async () => {
                 expect(num).to.within(refNum * 0.95, refNum * 1.05)
             })
 
-            /*
             it("maxRedeem", async () => {
                 await doDeposit()
-                expect(await longToken.maxRedeem(alice.address)).to.eq(test.deposit.expects.maxRedeem.expected)
+                var refVal = await longToken.totalSupply()
+                var val = await longToken.maxRedeem(alice.address)
+
+                var refNum = toNumber(refVal, test.quoteDecimals)
+                var num = toNumber(val, test.quoteDecimals)
+
+                expect(num).to.within(refNum * 0.95, refNum * 1.05)
             })
-            */
         })
     })
 })

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -135,7 +135,6 @@ describe("PerpdexLongToken base decimals", async () => {
         beforeEach(async () => {
             // alice approve longToken of max assets
             await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
-            await weth.approveForce(longToken.address, exchange.address, ethers.constants.MaxUint256)
         })
         ;[
             {
@@ -156,11 +155,11 @@ describe("PerpdexLongToken base decimals", async () => {
                 },
                 depositAssets: "100",
                 convertShares: "49.014802470346044505",
-                expected: "49.999999999999999999",
+                expected: "49.999999",
             },
         ].forEach(test => {
             it(test.title, async () => {
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parse18(test.pool.base), parse18(test.pool.quote))
 
                 // alice deposits
                 var depositAssets = parseAssets(test.depositAssets)
@@ -169,9 +168,7 @@ describe("PerpdexLongToken base decimals", async () => {
                     await longToken.connect(alice).deposit(depositAssets, alice.address)
                 }
 
-                expect(await longToken.convertToAssets(parseShares(test.convertShares))).to.eq(
-                    parseAssets(test.expected),
-                )
+                expect(await longToken.convertToAssets(parse18(test.convertShares))).to.eq(parseAssets(test.expected))
             })
         })
     })

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -91,6 +91,16 @@ describe("PerpdexLongToken base decimals", async () => {
                 shares: parseUnits("48.773350241428083695", 18),
                 expected: parseUnits("50", 6),
             },
+
+            previewWithdraw: {
+                assets: parseUnits("50", 6),
+                expected: parseUnits("49.258657209004482538", 18),
+            },
+
+            previewRedeem: {
+                shares: parseUnits("49.258657209004482538", 18),
+                expected: parseUnits("50", 6),
+            },
         },
     ].forEach(test => {
         describe(`assetDecimals == ${test.assetDecimals}\t`, async () => {
@@ -140,6 +150,16 @@ describe("PerpdexLongToken base decimals", async () => {
 
             it("previewMint", async () => {
                 expect(await longToken.previewMint(test.previewMint.shares)).to.eq(test.previewMint.expected)
+            })
+
+            it("previewWithdraw", async () => {
+                expect(await longToken.previewWithdraw(test.previewWithdraw.assets)).to.eq(
+                    test.previewWithdraw.expected,
+                )
+            })
+
+            it("previewRedeem", async () => {
+                expect(await longToken.previewRedeem(test.previewRedeem.shares)).to.eq(test.previewRedeem.expected)
             })
         })
     })

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -97,21 +97,13 @@ describe("PerpdexLongToken base decimals", async () => {
                         shares: parseUnits("49.258657209004482538", 18),
                     },
 
-                    maxDeposit: {
-                        expected: parseUnits("238.613139", 6),
-                    },
+                    maxDeposit: {},
 
-                    maxMint: {
-                        expected: parseUnits("249.420273619194367053", 18),
-                    },
+                    maxMint: {},
 
-                    maxWithdraw: {
-                        expected: parseUnits("257.211406", 6),
-                    },
+                    maxWithdraw: {},
 
-                    maxRedeem: {
-                        expected: parseUnits("99.009900990099009900", 18),
-                    },
+                    maxRedeem: {},
                 },
             },
         },
@@ -159,21 +151,13 @@ describe("PerpdexLongToken base decimals", async () => {
                         shares: parseUnits("49.258657209004482538", 18),
                     },
 
-                    maxDeposit: {
-                        expected: parseUnits("238.613139", 6),
-                    },
+                    maxDeposit: {},
 
-                    maxMint: {
-                        expected: parseUnits("249.420273619194367053", 18),
-                    },
+                    maxMint: {},
 
-                    maxWithdraw: {
-                        expected: parseUnits("257.211406", 6),
-                    },
+                    maxWithdraw: {},
 
-                    maxRedeem: {
-                        expected: parseUnits("99.009900990099009900", 18),
-                    },
+                    maxRedeem: {},
                 },
             },
         },

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -115,6 +115,68 @@ describe("PerpdexLongToken base decimals", async () => {
                 },
             },
         },
+        {
+            assetDecimals: 6,
+            quoteDecimals: 18,
+            pool: {
+                base: "10000",
+                quote: "40000",
+            },
+            isMarketAllowed: true,
+
+            deposit: {
+                assets: parseUnits("100", 6),
+                receiver: "alice",
+                expects: {
+                    balanceOf: {
+                        owner: "alice",
+                    },
+
+                    totalSupply: {},
+                    totalAssets: {},
+
+                    convertToShares: {
+                        assets: parseUnits("50", 6),
+                    },
+
+                    convertToAssets: {
+                        shares: parseUnits("50", 18),
+                    },
+
+                    previewDeposit: {
+                        assets: parseUnits("50", 6),
+                    },
+
+                    previewMint: {
+                        shares: parseUnits("48.773350241428083695", 18),
+                    },
+
+                    previewWithdraw: {
+                        assets: parseUnits("50", 6),
+                    },
+
+                    previewRedeem: {
+                        shares: parseUnits("49.258657209004482538", 18),
+                    },
+
+                    maxDeposit: {
+                        expected: parseUnits("238.613139", 6),
+                    },
+
+                    maxMint: {
+                        expected: parseUnits("249.420273619194367053", 18),
+                    },
+
+                    maxWithdraw: {
+                        expected: parseUnits("257.211406", 6),
+                    },
+
+                    maxRedeem: {
+                        expected: parseUnits("99.009900990099009900", 18),
+                    },
+                },
+            },
+        },
     ].forEach(test => {
         describe(`assetDecimals == ${test.assetDecimals}\t`, async () => {
             beforeEach(async () => {

--- a/test/longToken/decimals.test.ts
+++ b/test/longToken/decimals.test.ts
@@ -63,24 +63,6 @@ describe("PerpdexLongToken base decimals", async () => {
         ;[
             {
                 assetDecimals: 6,
-                title: "account value is zero",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: parseUnits("0", 6),
-
-                // args
-                convertToSharesAssets: 0,
-
-                // expected value
-                expectedTotalAssets: 0,
-                expectedConvertToShares: 0,
-            },
-            {
-                assetDecimals: 6,
-                title: "account value > 0",
                 pool: {
                     base: "10000",
                     quote: "10000",
@@ -89,14 +71,17 @@ describe("PerpdexLongToken base decimals", async () => {
                 depositAssets: parseUnits("100", 6),
 
                 // args
-                convertToSharesAssets: parseUnits("50", 6),
+                convertToSharesAssetsArg: parseUnits("50", 6),
+                convertToAssetsSharesArg: parseUnits("50", 18),
 
                 // expected value
+                expectedTotalSupply: parseUnits("99.009900990099009900", 18),
                 expectedTotalAssets: parseUnits("100.999999", 6),
                 expectedConvertToShares: parseUnits("49.014802955641123273", 18),
+                expectedConvertToAssets: parseUnits("51.004999", 6),
             },
         ].forEach(test => {
-            it(`(assetDecimals == ${test.assetDecimals})\t` + test.title, async () => {
+            it(`assetDecimals == ${test.assetDecimals}\t`, async () => {
                 await before(test.assetDecimals)
 
                 await initPool(fixture, parse18(test.pool.base), parse18(test.pool.quote))
@@ -112,8 +97,14 @@ describe("PerpdexLongToken base decimals", async () => {
                     await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
                 }
 
+                expect(await longToken.totalSupply()).to.eq(test.expectedTotalSupply)
                 expect(await longToken.totalAssets()).to.eq(test.expectedTotalAssets)
-                expect(await longToken.convertToShares(test.convertToSharesAssets)).to.eq(test.expectedConvertToShares)
+                expect(await longToken.convertToShares(test.convertToSharesAssetsArg)).to.eq(
+                    test.expectedConvertToShares,
+                )
+                expect(await longToken.convertToAssets(test.convertToAssetsSharesArg)).to.eq(
+                    test.expectedConvertToAssets,
+                )
             })
         })
     })

--- a/test/longToken/deposit.test.ts
+++ b/test/longToken/deposit.test.ts
@@ -74,7 +74,7 @@ describe("PerpdexLongToken deposit", async () => {
             },
         ].forEach(test => {
             it(test.title, async () => {
-                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
                 if (test.isMarketAllowed !== void 0) {
                     await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
@@ -145,7 +145,7 @@ describe("PerpdexLongToken deposit", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // pool
-                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
                 if (test.isMarketAllowed !== void 0) {
                     await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
@@ -230,7 +230,7 @@ describe("PerpdexLongToken deposit", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // pool
-                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
                 if (test.isMarketAllowed !== void 0) {
                     await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)

--- a/test/longToken/deposit.test.ts
+++ b/test/longToken/deposit.test.ts
@@ -54,6 +54,10 @@ describe("PerpdexLongToken deposit", async () => {
                 owner = fixture.owner
                 alice = fixture.alice
                 bob = fixture.bob
+
+                await weth.connect(owner).deposit({
+                    value: ethers.utils.parseEther("200"),
+                })
             })
 
             describe("maxDeposit", async () => {

--- a/test/longToken/deposit.test.ts
+++ b/test/longToken/deposit.test.ts
@@ -53,7 +53,7 @@ describe("PerpdexLongToken deposit", async () => {
                     base: "0",
                     quote: "0",
                 },
-                isMarkeAllowed: false,
+                isMarketAllowed: false,
                 expected: "0",
             },
             {
@@ -76,8 +76,8 @@ describe("PerpdexLongToken deposit", async () => {
             it(test.title, async () => {
                 await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
-                if (test.isMarkeAllowed !== void 0) {
-                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                if (test.isMarketAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
                 }
 
                 expect(await longToken.maxDeposit(alice.address)).to.eq(parseAssets(test.expected))
@@ -97,7 +97,7 @@ describe("PerpdexLongToken deposit", async () => {
                     base: "10",
                     quote: "10",
                 },
-                isMarkeAllowed: false,
+                isMarketAllowed: false,
                 aliceQuoteAssets: "1000",
                 depositAssets: "100",
                 revertedWith: "PE_CMA: market not allowed",
@@ -147,8 +147,8 @@ describe("PerpdexLongToken deposit", async () => {
                 // pool
                 await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
-                if (test.isMarkeAllowed !== void 0) {
-                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                if (test.isMarketAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
                 }
 
                 // alice balance
@@ -180,7 +180,7 @@ describe("PerpdexLongToken deposit", async () => {
                     base: "10",
                     quote: "10",
                 },
-                isMarkeAllowed: false,
+                isMarketAllowed: false,
                 aliceQuoteAssets: "1000",
                 depositAssets: "100",
                 revertedWith: "PE_CMA: market not allowed",
@@ -232,8 +232,8 @@ describe("PerpdexLongToken deposit", async () => {
                 // pool
                 await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
-                if (test.isMarkeAllowed !== void 0) {
-                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                if (test.isMarketAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
                 }
 
                 // alice balance

--- a/test/longToken/deposit.test.ts
+++ b/test/longToken/deposit.test.ts
@@ -70,7 +70,7 @@ describe("PerpdexLongToken deposit", async () => {
                     base: "10",
                     quote: "10",
                 },
-                expected: "0.246950765959598383",
+                expected: "0.240999270514668206",
             },
         ].forEach(test => {
             it(test.title, async () => {

--- a/test/longToken/deposit.test.ts
+++ b/test/longToken/deposit.test.ts
@@ -74,7 +74,7 @@ describe("PerpdexLongToken deposit", async () => {
             },
         ].forEach(test => {
             it(test.title, async () => {
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
                 if (test.isMarketAllowed !== void 0) {
                     await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
@@ -145,7 +145,7 @@ describe("PerpdexLongToken deposit", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // pool
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
                 if (test.isMarketAllowed !== void 0) {
                     await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
@@ -230,7 +230,7 @@ describe("PerpdexLongToken deposit", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // pool
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
                 if (test.isMarketAllowed !== void 0) {
                     await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)

--- a/test/longToken/fixtures.ts
+++ b/test/longToken/fixtures.ts
@@ -54,7 +54,10 @@ export function createPerpdexExchangeFixture(
 
         // long token
         const perpdexLongTokenF = await ethers.getContractFactory("PerpdexLongToken")
-        const perpdexLongToken = (await perpdexLongTokenF.deploy(perpdexMarket.address)) as PerpdexLongToken
+        const perpdexLongToken = (await perpdexLongTokenF.deploy(
+            perpdexMarket.address,
+            ethers.constants.AddressZero,
+        )) as PerpdexLongToken
 
         return {
             perpdexExchange,

--- a/test/longToken/fixtures.ts
+++ b/test/longToken/fixtures.ts
@@ -31,12 +31,16 @@ export function createPerpdexExchangeFixture(
         let weth = (await tokenFactory.deploy("TestWETH", "WETH", params.wethDecimals)) as TestERC20
         let settlementTokenAddress
         let wethAddress
+        let naitiveTokenSymbol
+
         if (params.settlementToken === "weth") {
             settlementTokenAddress = weth.address
             wethAddress = ethers.constants.AddressZero
+            naitiveTokenSymbol = ""
         } else if (params.settlementToken === "ETH") {
             settlementTokenAddress = ethers.constants.AddressZero
             wethAddress = weth.address
+            naitiveTokenSymbol = "ETH"
         }
 
         let baseDecimals = 18
@@ -67,7 +71,7 @@ export function createPerpdexExchangeFixture(
         const perpdexLongToken = (await perpdexLongTokenF.deploy(
             perpdexMarket.address,
             wethAddress,
-            "ETH",
+            naitiveTokenSymbol,
         )) as PerpdexLongToken
 
         return {

--- a/test/longToken/fixtures.ts
+++ b/test/longToken/fixtures.ts
@@ -41,6 +41,8 @@ export function createPerpdexExchangeFixture(
             settlementTokenAddress = ethers.constants.AddressZero
             wethAddress = weth.address
             naitiveTokenSymbol = "ETH"
+
+            await weth.connect(owner).deposit({ value: ethers.utils.parseEther("10") })
         }
 
         let baseDecimals = 18

--- a/test/longToken/fixtures.ts
+++ b/test/longToken/fixtures.ts
@@ -67,6 +67,7 @@ export function createPerpdexExchangeFixture(
         const perpdexLongToken = (await perpdexLongTokenF.deploy(
             perpdexMarket.address,
             wethAddress,
+            "ETH",
         )) as PerpdexLongToken
 
         return {

--- a/test/longToken/fixtures.ts
+++ b/test/longToken/fixtures.ts
@@ -42,7 +42,9 @@ export function createPerpdexExchangeFixture(
             wethAddress = weth.address
             naitiveTokenSymbol = "ETH"
 
-            await weth.connect(owner).deposit({ value: ethers.utils.parseEther("10") })
+            await weth.connect(owner).deposit({
+                value: ethers.utils.parseEther("200"),
+            })
         }
 
         let baseDecimals = 18

--- a/test/longToken/fixtures.ts
+++ b/test/longToken/fixtures.ts
@@ -41,10 +41,6 @@ export function createPerpdexExchangeFixture(
             settlementTokenAddress = ethers.constants.AddressZero
             wethAddress = weth.address
             naitiveTokenSymbol = "ETH"
-
-            await weth.connect(owner).deposit({
-                value: ethers.utils.parseEther("200"),
-            })
         }
 
         let baseDecimals = 18

--- a/test/longToken/helpers.ts
+++ b/test/longToken/helpers.ts
@@ -2,7 +2,7 @@
 import { BigNumber } from "ethers"
 import { ethers } from "hardhat"
 
-export async function initPool(fixture, base, quote): Promise<void> {
+export async function initPool(fixture, base, quote, baseBalancePerShareX96 = void 0): Promise<void> {
     let exchange = fixture.perpdexExchange
     let market = fixture.perpdexMarket
     let owner = fixture.owner
@@ -31,5 +31,12 @@ export async function initPool(fixture, base, quote): Promise<void> {
             minQuote: 0,
             deadline: ethers.constants.MaxUint256,
         })
+        if (baseBalancePerShareX96) {
+            const poolInfo = await market.poolInfo()
+            await market.setPoolInfo({
+                ...poolInfo,
+                baseBalancePerShareX96: baseBalancePerShareX96,
+            })
+        }
     }
 }

--- a/test/longToken/helpers.ts
+++ b/test/longToken/helpers.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+import { BigNumber } from "ethers"
 import { ethers } from "hardhat"
 
-export async function initPool(exchange, market, owner, base, quote): Promise<void> {
+export async function initPool(fixture, base, quote): Promise<void> {
+    let exchange = fixture.perpdexExchange
+    let market = fixture.perpdexMarket
+    let owner = fixture.owner
+    let priceFeedBase = fixture.priceFeedBase
+
     await market.connect(owner).setFundingMaxPremiumRatio(0)
     await exchange.connect(owner).setIsMarketAllowed(market.address, true)
 
@@ -14,6 +20,9 @@ export async function initPool(exchange, market, owner, base, quote): Promise<vo
     )
 
     if (base.gt(0) && quote.gt(0)) {
+        // mock price feed before add liquidity
+        var basePrice = quote.div(base).mul(BigNumber.from(10).pow(await priceFeedBase.decimals()))
+        await priceFeedBase.mock.getPrice.returns(basePrice)
         await exchange.connect(owner).addLiquidity({
             market: market.address,
             base: base,

--- a/test/longToken/metadata.test.ts
+++ b/test/longToken/metadata.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { expect } from "chai"
+import { BigNumber, Wallet } from "ethers"
+import { parseUnits } from "ethers/lib/utils"
+import { ethers, waffle } from "hardhat"
+import { PerpdexLongToken, TestERC20, TestPerpdexExchange, TestPerpdexMarket } from "../../typechain"
+import { createPerpdexExchangeFixture } from "./fixtures"
+import { initPool } from "./helpers"
+
+describe("PerpdexLongToken metadata", async () => {
+    let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+    let fixture
+
+    let longToken: PerpdexLongToken
+
+    describe("native token", () => {
+        beforeEach(async () => {
+            fixture = await loadFixture(
+                createPerpdexExchangeFixture({
+                    settlementToken: "ETH",
+                    wethDecimals: 18,
+                }),
+            )
+            longToken = fixture.perpdexLongToken
+        })
+
+        it("symbol", async () => {
+            expect(await longToken.symbol()).to.eq("plUSDETH")
+        })
+
+        it("name", async () => {
+            expect(await longToken.name()).to.eq("PerpDEX Long USDETH")
+        })
+
+        it("decimals", async () => {
+            expect(await longToken.decimals()).to.eq(18)
+        })
+    })
+
+    describe("weth", () => {
+        beforeEach(async () => {
+            fixture = await loadFixture(createPerpdexExchangeFixture())
+            longToken = fixture.perpdexLongToken
+        })
+
+        it("symbol", async () => {
+            expect(await longToken.symbol()).to.eq("plUSDWETH")
+        })
+
+        it("name", async () => {
+            expect(await longToken.name()).to.eq("PerpDEX Long USDWETH")
+        })
+
+        it("decimals", async () => {
+            expect(await longToken.decimals()).to.eq(18)
+        })
+    })
+})

--- a/test/longToken/mint.eth.test.ts
+++ b/test/longToken/mint.eth.test.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { expect } from "chai"
+import { Wallet } from "ethers"
+import { parseUnits } from "ethers/lib/utils"
+import { ethers, waffle } from "hardhat"
+import { PerpdexLongToken, TestERC20, TestPerpdexExchange, TestPerpdexMarket } from "../../typechain"
+import { createPerpdexExchangeFixture } from "./fixtures"
+import { initPool } from "./helpers"
+
+describe("PerpdexLongToken mint", async () => {
+    let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+    let fixture
+
+    let longToken: PerpdexLongToken
+    let longTokenDecimals: number
+    let market: TestPerpdexMarket
+    let exchange: TestPerpdexExchange
+    let weth: TestERC20
+    let wethDecimals: number
+    let owner: Wallet
+    let alice: Wallet
+    let bob: Wallet
+
+    beforeEach(async () => {
+        fixture = await loadFixture(createPerpdexExchangeFixture({ settlementToken: "ETH", wethDecimals: 18 }))
+
+        longToken = fixture.perpdexLongToken
+        longTokenDecimals = await longToken.decimals()
+        market = fixture.perpdexMarket
+        exchange = fixture.perpdexExchange
+
+        weth = fixture.weth
+        wethDecimals = await weth.decimals()
+
+        owner = fixture.owner
+        alice = fixture.alice
+        bob = fixture.bob
+    })
+
+    function parseShares(amount: string) {
+        return parseUnits(amount, longTokenDecimals)
+    }
+
+    describe("mintETH", async () => {
+        beforeEach(async () => {
+            // alice approve longToken of max assets
+            await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
+        })
+        ;[
+            {
+                title: "reverts when market is not allowed",
+                pool: {
+                    base: "10",
+                    quote: "10",
+                },
+                isMarketAllowed: false,
+                aliceQuoteAssets: "1000",
+                mintShares: "100",
+                sendETHValue: "110",
+                revertedWith: "PM_PS: too large amount", // maxMint == 0
+            },
+            {
+                title: "reverts when liquidity is zero",
+                pool: {
+                    base: "0",
+                    quote: "0",
+                },
+                aliceQuoteAssets: "1000",
+                mintShares: "100",
+                sendETHValue: "110",
+                revertedWith: "PM_PS: too large amount", // maxMint == 0
+            },
+            {
+                title: "reverts when assets is zero",
+                pool: {
+                    base: "10",
+                    quote: "10",
+                },
+                aliceQuoteAssets: "1000",
+                mintShares: "0",
+                sendETHValue: "0",
+                revertedWith: "PL_SD: output is zero",
+            },
+            {
+                title: "reverts when assets is too large",
+                pool: {
+                    base: "10",
+                    quote: "10",
+                },
+                aliceQuoteAssets: "1000",
+                mintShares: "100",
+                sendETHValue: "110",
+                revertedWith: "PM_PS: too large amount",
+            },
+            // unnecessary?
+            // {
+            //     title: "reverts when send ETH value is lower than previewMint",
+            //     pool: {
+            //         base: "10000",
+            //         quote: "10000",
+            //     },
+            //     aliceQuoteAssets: "50",
+            //     mintShares: "20",
+            //     sendETHValue: "10",
+            //     revertedWith: "SafeMath: subtraction overflow",
+            // },
+            {
+                title: "succeeds",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                aliceQuoteAssets: "50",
+                mintShares: "20",
+                sendETHValue: "30",
+                depositedAssets: "20.040080160320641283",
+                totalAssetsAfter: "20.080240641603848980",
+                aliceAssetsAfter: "29.959919839679358717",
+            },
+        ].forEach(test => {
+            it(test.title, async () => {
+                // pool
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+
+                // alice mint preview
+                var mintShares = parseShares(test.mintShares)
+                var previewSubject = longToken.connect(alice).previewMint(mintShares)
+
+                // alice mints
+                var mintSubject = longToken
+                    .connect(alice)
+                    .mintETH(mintShares, alice.address, { value: parseUnits(test.sendETHValue, 18) })
+
+                // assert
+                if (test.revertedWith !== void 0) {
+                    await expect(previewSubject).to.reverted
+                    await expect(mintSubject).to.revertedWith(test.revertedWith)
+                } else {
+                    var depositedAssets = parseUnits(test.depositedAssets, 18)
+                    // event
+                    expect(await mintSubject)
+                        .to.emit(longToken, "Deposit")
+                        .withArgs(alice.address, alice.address, depositedAssets, mintShares)
+
+                    // share
+                    expect(await longToken.totalSupply()).to.eq(mintShares)
+                    expect(await longToken.balanceOf(alice.address)).to.eq(mintShares)
+
+                    // asset
+                    expect(await longToken.totalAssets()).to.eq(parseUnits(test.totalAssetsAfter, 18))
+                    expect(await mintSubject).to.changeEtherBalance(alice, depositedAssets)
+
+                    // preview >= assets
+                    expect(await previewSubject).to.gte(depositedAssets)
+                }
+            })
+        })
+    })
+})

--- a/test/longToken/mint.eth.test.ts
+++ b/test/longToken/mint.eth.test.ts
@@ -92,18 +92,18 @@ describe("PerpdexLongToken mint", async () => {
                 sendETHValue: "110",
                 revertedWith: "PM_PS: too large amount",
             },
-            // unnecessary?
-            // {
-            //     title: "reverts when send ETH value is lower than previewMint",
-            //     pool: {
-            //         base: "10000",
-            //         quote: "10000",
-            //     },
-            //     aliceQuoteAssets: "50",
-            //     mintShares: "20",
-            //     sendETHValue: "10",
-            //     revertedWith: "SafeMath: subtraction overflow",
-            // },
+            {
+                title: "reverts when send ETH value is lower than previewMint",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                aliceQuoteAssets: "50",
+                mintShares: "20",
+                sendETHValue: "10",
+                revertedWith: "SafeMath: subtraction overflow",
+                skipPreviewSubjectRevertAssert: true,
+            },
             {
                 title: "succeeds",
                 pool: {
@@ -133,7 +133,9 @@ describe("PerpdexLongToken mint", async () => {
 
                 // assert
                 if (test.revertedWith !== void 0) {
-                    await expect(previewSubject).to.reverted
+                    if (!test.skipPreviewSubjectRevertAssert) {
+                        await expect(previewSubject).to.reverted
+                    }
                     await expect(mintSubject).to.revertedWith(test.revertedWith)
                 } else {
                     var depositedAssets = parseUnits(test.depositedAssets, 18)

--- a/test/longToken/mint.test.ts
+++ b/test/longToken/mint.test.ts
@@ -75,7 +75,7 @@ describe("PerpdexLongToken mint", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // init pool
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
                 if (test.isMarketAllowed !== void 0) {
                     await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
@@ -146,7 +146,7 @@ describe("PerpdexLongToken mint", async () => {
             },
         ].forEach(test => {
             it(test.title, async () => {
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
                 if (test.isMarketAllowed !== void 0) {
                     await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
@@ -231,7 +231,7 @@ describe("PerpdexLongToken mint", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // pool
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
                 // alice balance
                 await weth.connect(owner).mint(alice.address, parseAssets(test.aliceQuoteAssets))

--- a/test/longToken/mint.test.ts
+++ b/test/longToken/mint.test.ts
@@ -70,7 +70,7 @@ describe("PerpdexLongToken mint", async () => {
                     base: "10",
                     quote: "10",
                 },
-                expected: "0.240999270514668206",
+                expected: "0.246950765959598383",
             },
         ].forEach(test => {
             it(test.title, async () => {

--- a/test/longToken/mint.test.ts
+++ b/test/longToken/mint.test.ts
@@ -54,6 +54,10 @@ describe("PerpdexLongToken mint", async () => {
                 owner = fixture.owner
                 alice = fixture.alice
                 bob = fixture.bob
+
+                await weth.connect(owner).deposit({
+                    value: ethers.utils.parseEther("200"),
+                })
             })
 
             describe("maxMint", async () => {

--- a/test/longToken/mint.test.ts
+++ b/test/longToken/mint.test.ts
@@ -75,7 +75,7 @@ describe("PerpdexLongToken mint", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // init pool
-                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
                 if (test.isMarketAllowed !== void 0) {
                     await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
@@ -146,7 +146,7 @@ describe("PerpdexLongToken mint", async () => {
             },
         ].forEach(test => {
             it(test.title, async () => {
-                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
                 if (test.isMarketAllowed !== void 0) {
                     await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
@@ -231,7 +231,7 @@ describe("PerpdexLongToken mint", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // pool
-                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
                 // alice balance
                 await weth.connect(owner).mint(alice.address, parseAssets(test.aliceQuoteAssets))

--- a/test/longToken/mint.test.ts
+++ b/test/longToken/mint.test.ts
@@ -53,7 +53,7 @@ describe("PerpdexLongToken mint", async () => {
                     base: "0",
                     quote: "0",
                 },
-                isMarkeAllowed: false,
+                isMarketAllowed: false,
                 expected: "0",
             },
             {
@@ -77,8 +77,8 @@ describe("PerpdexLongToken mint", async () => {
                 // init pool
                 await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
-                if (test.isMarkeAllowed !== void 0) {
-                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                if (test.isMarketAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
                 }
 
                 expect(await longToken.maxMint(alice.address)).to.eq(parseShares(test.expected))
@@ -99,7 +99,7 @@ describe("PerpdexLongToken mint", async () => {
                     base: "10",
                     quote: "10",
                 },
-                isMarkeAllowed: false,
+                isMarketAllowed: false,
                 aliceQuoteAssets: "1000",
                 mintShares: "100",
                 revertedWith: "PE_CMA: market not allowed",
@@ -148,8 +148,8 @@ describe("PerpdexLongToken mint", async () => {
             it(test.title, async () => {
                 await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
-                if (test.isMarkeAllowed !== void 0) {
-                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                if (test.isMarketAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
                 }
 
                 // alice balance
@@ -181,7 +181,7 @@ describe("PerpdexLongToken mint", async () => {
                     base: "10",
                     quote: "10",
                 },
-                isMarkeAllowed: false,
+                isMarketAllowed: false,
                 aliceQuoteAssets: "1000",
                 mintShares: "100",
                 revertedWith: "PM_PS: too large amount", // maxMint == 0

--- a/test/longToken/mint.test.ts
+++ b/test/longToken/mint.test.ts
@@ -21,22 +21,6 @@ describe("PerpdexLongToken mint", async () => {
     let alice: Wallet
     let bob: Wallet
 
-    beforeEach(async () => {
-        fixture = await loadFixture(createPerpdexExchangeFixture())
-
-        longToken = fixture.perpdexLongToken
-        longTokenDecimals = await longToken.decimals()
-        market = fixture.perpdexMarket
-        exchange = fixture.perpdexExchange
-
-        weth = fixture.weth
-        wethDecimals = await weth.decimals()
-
-        owner = fixture.owner
-        alice = fixture.alice
-        bob = fixture.bob
-    })
-
     function parseAssets(amount: string) {
         return parseUnits(amount, wethDecimals)
     }
@@ -45,226 +29,255 @@ describe("PerpdexLongToken mint", async () => {
         return parseUnits(amount, longTokenDecimals)
     }
 
-    describe("maxMint", async () => {
-        ;[
-            {
-                title: "returns 0 when market is not allowed",
-                pool: {
-                    base: "0",
-                    quote: "0",
-                },
-                isMarketAllowed: false,
-                expected: "0",
-            },
-            {
-                title: "returns 0 when pool liquidity is zero",
-                pool: {
-                    base: "0",
-                    quote: "0",
-                },
-                expected: "0",
-            },
-            {
-                title: "succeeds",
-                pool: {
-                    base: "10",
-                    quote: "10",
-                },
-                expected: "0.246950765959598383",
-            },
-        ].forEach(test => {
-            it(test.title, async () => {
-                // init pool
-                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+    ;[
+        {
+            settlementToken: "weth",
+            wethDecimals: 18,
+        },
+        {
+            settlementToken: "ETH",
+            wethDecimals: 18,
+        },
+    ].forEach(fixtureParams => {
+        describe(JSON.stringify(fixtureParams), () => {
+            beforeEach(async () => {
+                fixture = await loadFixture(createPerpdexExchangeFixture(fixtureParams))
 
-                if (test.isMarketAllowed !== void 0) {
-                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
-                }
+                longToken = fixture.perpdexLongToken
+                longTokenDecimals = await longToken.decimals()
+                market = fixture.perpdexMarket
+                exchange = fixture.perpdexExchange
 
-                expect(await longToken.maxMint(alice.address)).to.eq(parseShares(test.expected))
+                weth = fixture.weth
+                wethDecimals = await weth.decimals()
+
+                owner = fixture.owner
+                alice = fixture.alice
+                bob = fixture.bob
             })
-        })
-    })
 
-    describe("previewMint", async () => {
-        beforeEach(async () => {
-            // alice approve longToken of max assets
-            await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
-            await weth.approveForce(longToken.address, exchange.address, ethers.constants.MaxUint256)
-        })
-        ;[
-            {
-                title: "reverts when market is not allowed",
-                pool: {
-                    base: "10",
-                    quote: "10",
-                },
-                isMarketAllowed: false,
-                aliceQuoteAssets: "1000",
-                mintShares: "100",
-                revertedWith: "PE_CMA: market not allowed",
-            },
-            {
-                title: "reverts when liquidity is zero",
-                pool: {
-                    base: "0",
-                    quote: "0",
-                },
-                aliceQuoteAssets: "1000",
-                mintShares: "100",
-                revertedWith: "PM_PS: too large amount",
-            },
-            {
-                title: "reverts when assets is zero",
-                pool: {
-                    base: "10",
-                    quote: "10",
-                },
-                aliceQuoteAssets: "1000",
-                mintShares: "0",
-                revertedWith: "PL_SD: output is zero",
-            },
-            {
-                title: "reverts when assets is too large",
-                pool: {
-                    base: "10",
-                    quote: "10",
-                },
-                aliceQuoteAssets: "1000",
-                mintShares: "100",
-                revertedWith: "PM_PS: too large amount",
-            },
-            {
-                title: "succeeds",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                aliceQuoteAssets: "500",
-                mintShares: "10",
-                depositedAssets: "10.010010010010010011",
-            },
-        ].forEach(test => {
-            it(test.title, async () => {
-                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+            describe("maxMint", async () => {
+                ;[
+                    {
+                        title: "returns 0 when market is not allowed",
+                        pool: {
+                            base: "0",
+                            quote: "0",
+                        },
+                        isMarketAllowed: false,
+                        expected: "0",
+                    },
+                    {
+                        title: "returns 0 when pool liquidity is zero",
+                        pool: {
+                            base: "0",
+                            quote: "0",
+                        },
+                        expected: "0",
+                    },
+                    {
+                        title: "succeeds",
+                        pool: {
+                            base: "10",
+                            quote: "10",
+                        },
+                        expected: "0.246950765959598383",
+                    },
+                ].forEach(test => {
+                    it(test.title, async () => {
+                        // init pool
+                        await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
-                if (test.isMarketAllowed !== void 0) {
-                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
-                }
+                        if (test.isMarketAllowed !== void 0) {
+                            await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
+                        }
 
-                // alice balance
-                await weth.connect(owner).mint(alice.address, parseAssets(test.aliceQuoteAssets))
-
-                // alice preview mint
-                var mintShares = parseShares(test.mintShares)
-                var subject = longToken.connect(alice).previewMint(mintShares)
-
-                // assert
-                if (test.revertedWith !== void 0) {
-                    await expect(subject).to.revertedWith(test.revertedWith)
-                } else {
-                    expect(await subject).to.eq(parseShares(test.depositedAssets))
-                }
+                        expect(await longToken.maxMint(alice.address)).to.eq(parseShares(test.expected))
+                    })
+                })
             })
-        })
-    })
 
-    describe("mint", async () => {
-        beforeEach(async () => {
-            // alice approve longToken of max assets
-            await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
-        })
-        ;[
-            {
-                title: "reverts when market is not allowed",
-                pool: {
-                    base: "10",
-                    quote: "10",
-                },
-                isMarketAllowed: false,
-                aliceQuoteAssets: "1000",
-                mintShares: "100",
-                revertedWith: "PM_PS: too large amount", // maxMint == 0
-            },
-            {
-                title: "reverts when liquidity is zero",
-                pool: {
-                    base: "0",
-                    quote: "0",
-                },
-                aliceQuoteAssets: "1000",
-                mintShares: "100",
-                revertedWith: "PM_PS: too large amount", // maxMint == 0
-            },
-            {
-                title: "reverts when assets is zero",
-                pool: {
-                    base: "10",
-                    quote: "10",
-                },
-                aliceQuoteAssets: "1000",
-                mintShares: "0",
-                revertedWith: "PL_SD: output is zero",
-            },
-            {
-                title: "reverts when assets is too large",
-                pool: {
-                    base: "10",
-                    quote: "10",
-                },
-                aliceQuoteAssets: "1000",
-                mintShares: "100",
-                revertedWith: "PM_PS: too large amount",
-            },
-            {
-                title: "succeeds",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                aliceQuoteAssets: "50",
-                mintShares: "20",
-                depositedAssets: "20.040080160320641283",
-                totalAssetsAfter: "20.080240641603848980",
-                aliceAssetsAfter: "29.959919839679358717",
-            },
-        ].forEach(test => {
-            it(test.title, async () => {
-                // pool
-                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+            describe("previewMint", async () => {
+                beforeEach(async () => {
+                    // alice approve longToken of max assets
+                    await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
+                    await weth.approveForce(longToken.address, exchange.address, ethers.constants.MaxUint256)
+                })
+                ;[
+                    {
+                        title: "reverts when market is not allowed",
+                        pool: {
+                            base: "10",
+                            quote: "10",
+                        },
+                        isMarketAllowed: false,
+                        aliceQuoteAssets: "1000",
+                        mintShares: "100",
+                        revertedWith: "PE_CMA: market not allowed",
+                    },
+                    {
+                        title: "reverts when liquidity is zero",
+                        pool: {
+                            base: "0",
+                            quote: "0",
+                        },
+                        aliceQuoteAssets: "1000",
+                        mintShares: "100",
+                        revertedWith: "PM_PS: too large amount",
+                    },
+                    {
+                        title: "reverts when assets is zero",
+                        pool: {
+                            base: "10",
+                            quote: "10",
+                        },
+                        aliceQuoteAssets: "1000",
+                        mintShares: "0",
+                        revertedWith: "PL_SD: output is zero",
+                    },
+                    {
+                        title: "reverts when assets is too large",
+                        pool: {
+                            base: "10",
+                            quote: "10",
+                        },
+                        aliceQuoteAssets: "1000",
+                        mintShares: "100",
+                        revertedWith: "PM_PS: too large amount",
+                    },
+                    {
+                        title: "succeeds",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        aliceQuoteAssets: "500",
+                        mintShares: "10",
+                        depositedAssets: "10.010010010010010011",
+                    },
+                ].forEach(test => {
+                    it(test.title, async () => {
+                        await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
-                // alice balance
-                await weth.connect(owner).mint(alice.address, parseAssets(test.aliceQuoteAssets))
+                        if (test.isMarketAllowed !== void 0) {
+                            await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
+                        }
 
-                // alice mint preview
-                var mintShares = parseShares(test.mintShares)
-                var previewSubject = longToken.connect(alice).previewMint(mintShares)
+                        // alice balance
+                        await weth.connect(owner).mint(alice.address, parseAssets(test.aliceQuoteAssets))
 
-                // alice mints
-                var mintSubject = longToken.connect(alice).mint(mintShares, alice.address)
+                        // alice preview mint
+                        var mintShares = parseShares(test.mintShares)
+                        var subject = longToken.connect(alice).previewMint(mintShares)
 
-                // assert
-                if (test.revertedWith !== void 0) {
-                    await expect(previewSubject).to.reverted
-                    await expect(mintSubject).to.revertedWith(test.revertedWith)
-                } else {
-                    var depositedAssets = parseAssets(test.depositedAssets)
-                    // event
-                    expect(await mintSubject)
-                        .to.emit(longToken, "Deposit")
-                        .withArgs(alice.address, alice.address, depositedAssets, mintShares)
+                        // assert
+                        if (test.revertedWith !== void 0) {
+                            await expect(subject).to.revertedWith(test.revertedWith)
+                        } else {
+                            expect(await subject).to.eq(parseShares(test.depositedAssets))
+                        }
+                    })
+                })
+            })
 
-                    // share
-                    expect(await longToken.totalSupply()).to.eq(mintShares)
-                    expect(await longToken.balanceOf(alice.address)).to.eq(mintShares)
+            describe("mint", async () => {
+                beforeEach(async () => {
+                    // alice approve longToken of max assets
+                    await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
+                })
+                ;[
+                    {
+                        title: "reverts when market is not allowed",
+                        pool: {
+                            base: "10",
+                            quote: "10",
+                        },
+                        isMarketAllowed: false,
+                        aliceQuoteAssets: "1000",
+                        mintShares: "100",
+                        revertedWith: "PM_PS: too large amount", // maxMint == 0
+                    },
+                    {
+                        title: "reverts when liquidity is zero",
+                        pool: {
+                            base: "0",
+                            quote: "0",
+                        },
+                        aliceQuoteAssets: "1000",
+                        mintShares: "100",
+                        revertedWith: "PM_PS: too large amount", // maxMint == 0
+                    },
+                    {
+                        title: "reverts when assets is zero",
+                        pool: {
+                            base: "10",
+                            quote: "10",
+                        },
+                        aliceQuoteAssets: "1000",
+                        mintShares: "0",
+                        revertedWith: "PL_SD: output is zero",
+                    },
+                    {
+                        title: "reverts when assets is too large",
+                        pool: {
+                            base: "10",
+                            quote: "10",
+                        },
+                        aliceQuoteAssets: "1000",
+                        mintShares: "100",
+                        revertedWith: "PM_PS: too large amount",
+                    },
+                    {
+                        title: "succeeds",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        aliceQuoteAssets: "50",
+                        mintShares: "20",
+                        depositedAssets: "20.040080160320641283",
+                        totalAssetsAfter: "20.080240641603848980",
+                        aliceAssetsAfter: "29.959919839679358717",
+                    },
+                ].forEach(test => {
+                    it(test.title, async () => {
+                        // pool
+                        await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
-                    // asset
-                    expect(await longToken.totalAssets()).to.eq(parseAssets(test.totalAssetsAfter))
-                    expect(await weth.balanceOf(alice.address)).to.eq(parseAssets(test.aliceAssetsAfter))
+                        // alice balance
+                        await weth.connect(owner).mint(alice.address, parseAssets(test.aliceQuoteAssets))
 
-                    // preview >= assets
-                    expect(await previewSubject).to.gte(depositedAssets)
-                }
+                        // alice mint preview
+                        var mintShares = parseShares(test.mintShares)
+                        var previewSubject = longToken.connect(alice).previewMint(mintShares)
+
+                        // alice mints
+                        var mintSubject = longToken.connect(alice).mint(mintShares, alice.address)
+
+                        // assert
+                        if (test.revertedWith !== void 0) {
+                            await expect(previewSubject).to.reverted
+                            await expect(mintSubject).to.revertedWith(test.revertedWith)
+                        } else {
+                            var depositedAssets = parseAssets(test.depositedAssets)
+                            // event
+                            expect(await mintSubject)
+                                .to.emit(longToken, "Deposit")
+                                .withArgs(alice.address, alice.address, depositedAssets, mintShares)
+
+                            // share
+                            expect(await longToken.totalSupply()).to.eq(mintShares)
+                            expect(await longToken.balanceOf(alice.address)).to.eq(mintShares)
+
+                            // asset
+                            expect(await longToken.totalAssets()).to.eq(parseAssets(test.totalAssetsAfter))
+                            expect(await weth.balanceOf(alice.address)).to.eq(parseAssets(test.aliceAssetsAfter))
+
+                            // preview >= assets
+                            expect(await previewSubject).to.gte(depositedAssets)
+                        }
+                    })
+                })
             })
         })
     })

--- a/test/longToken/redeem.eth.test.ts
+++ b/test/longToken/redeem.eth.test.ts
@@ -7,7 +7,7 @@ import { PerpdexLongToken, TestERC20, TestPerpdexExchange, TestPerpdexMarket } f
 import { createPerpdexExchangeFixture } from "./fixtures"
 import { initPool } from "./helpers"
 
-describe("PerpdexLongToken redeem", async () => {
+describe("PerpdexLongToken redeem ETH", async () => {
     let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
     let fixture
 

--- a/test/longToken/redeem.eth.test.ts
+++ b/test/longToken/redeem.eth.test.ts
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { expect } from "chai"
+import { Wallet } from "ethers"
+import { parseUnits } from "ethers/lib/utils"
+import { ethers, waffle } from "hardhat"
+import { PerpdexLongToken, TestERC20, TestPerpdexExchange, TestPerpdexMarket } from "../../typechain"
+import { createPerpdexExchangeFixture } from "./fixtures"
+import { initPool } from "./helpers"
+
+describe("PerpdexLongToken redeem", async () => {
+    let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+    let fixture
+
+    let longToken: PerpdexLongToken
+    let longTokenDecimals: number
+    let market: TestPerpdexMarket
+    let exchange: TestPerpdexExchange
+    let weth: TestERC20
+    let wethDecimals: number
+    let owner: Wallet
+    let alice: Wallet
+    let bob: Wallet
+    let charlie: Wallet
+
+    beforeEach(async () => {
+        fixture = await loadFixture(createPerpdexExchangeFixture({ settlementToken: "ETH", wethDecimals: 18 }))
+
+        longToken = fixture.perpdexLongToken
+        longTokenDecimals = await longToken.decimals()
+        market = fixture.perpdexMarket
+        exchange = fixture.perpdexExchange
+
+        weth = fixture.weth
+        wethDecimals = await weth.decimals()
+
+        owner = fixture.owner
+        alice = fixture.alice
+        bob = fixture.bob
+        charlie = fixture.charlie
+    })
+
+    function parseAssets(amount: string) {
+        return parseUnits(amount, wethDecimals)
+    }
+
+    function parseShares(amount: string) {
+        return parseUnits(amount, longTokenDecimals)
+    }
+
+    function toWallet(who: string) {
+        if (who === "alice") {
+            return alice
+        }
+        if (who === "bob") {
+            return bob
+        }
+        if (who === "charlie") {
+            return charlie
+        }
+    }
+
+    describe("maxRedeem", async () => {
+        beforeEach(async () => {
+            // alice approve longToken of max assets
+            await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
+            await weth.approveForce(longToken.address, exchange.address, ethers.constants.MaxUint256)
+        })
+        ;[
+            {
+                title: "returns 0 when market is not allowed",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: false,
+                depositAssets: "10",
+                expected: "0",
+            },
+            {
+                title: "returns 0 when pool liquidity is zero",
+                pool: {
+                    base: "0",
+                    quote: "0",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                expected: "0",
+            },
+            {
+                title: "returns owner's shares",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                expected: "9.990009990009990009",
+            },
+            {
+                title: "returns owner's 0 shares",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "0",
+                expected: "0",
+            },
+        ].forEach(test => {
+            it(test.title, async () => {
+                // init pool
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+
+                await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
+
+                // alice deposits
+                await weth.connect(owner).mint(alice.address, parseAssets(test.depositAssets))
+
+                // deposit only when market is allowed and pool has liquidity
+                if (test.isMarketAllowed && test.pool.base !== "0" && test.depositAssets !== "0") {
+                    await longToken.connect(alice).deposit(parseAssets(test.depositAssets), alice.address)
+                }
+
+                // alice maxRedeem
+                expect(await longToken.connect(alice).maxRedeem(alice.address)).to.eq(parseAssets(test.expected))
+            })
+        })
+    })
+
+    describe("previewRedeem and redeem", async () => {
+        beforeEach(async () => {
+            // alice approve longToken of max assets
+            await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
+            // bob approve longToken of max assets
+            await weth.approveForce(bob.address, longToken.address, ethers.constants.MaxUint256)
+        })
+        ;[
+            {
+                title: "both reverts when market is not allowed",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: false,
+                depositAssets: "10",
+                redeemShares: "5",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "alice",
+                receiver: "alice",
+                revertedWithPreview: "PE_CMA: market not allowed",
+                revertedWith: "PE_CMA: market not allowed", // maxWithdraw == 0
+            },
+            {
+                title: "both reverts when shares is zero",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                redeemShares: "0",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "alice",
+                receiver: "alice",
+                revertedWithPreview: "PL_SD: output is zero",
+                revertedWith: "PL_SD: output is zero'",
+            },
+            {
+                title: "redeem reverts and preview succeeds when shares is more than max",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                redeemShares: "20",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "alice",
+                receiver: "alice",
+                withdrawnAssetsPreview: "19.999980039960000079",
+                revertedWith: "ERC20: burn amount exceeds balance",
+            },
+            {
+                title: "redeem reverts and preview succeeds when alice redeems unapproved bob's shares",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                redeemShares: "9.9",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "bob",
+                receiver: "alice",
+                withdrawnAssetsPreview: "9.909989199802887336",
+                revertedWith: "ERC20: transfer amount exceeds allowance",
+            },
+            {
+                title: "succeeds when alice redeems her shares",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                redeemShares: "9.9",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "alice",
+                receiver: "alice",
+                withdrawnAssetsPreview: "9.909989199802887336",
+                withdrawnAssets: "9.909989199802887336",
+            },
+            {
+                title: "succeeds when alice redeems approved bob's shares to alice",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                redeemShares: "9.9",
+                ownerAllowance: "9.9",
+                caller: "alice",
+                owner: "bob",
+                receiver: "alice",
+                withdrawnAssetsPreview: "9.909989199802887336",
+                withdrawnAssets: "9.909989199802887336",
+            },
+            {
+                title: "succeeds when alice redeems approved bob's shares to charlie",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                redeemShares: "9.9",
+                ownerAllowance: "9.9",
+                caller: "alice",
+                owner: "bob",
+                receiver: "charlie",
+                withdrawnAssetsPreview: "9.909989199802887336",
+                withdrawnAssets: "9.909989199802887336",
+            },
+        ].forEach(test => {
+            it(test.title, async () => {
+                // pool
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+
+                var caller = toWallet(test.caller)
+                var owner_ = toWallet(test.owner)
+                var receiver = toWallet(test.receiver)
+
+                // owner_ deposit
+                var depositAssets = parseAssets(test.depositAssets)
+                await weth.connect(owner).mint(owner_.address, depositAssets)
+                await longToken.connect(owner_).deposit(parseAssets(test.depositAssets), owner_.address)
+
+                // owner_ approves caller
+                await longToken.connect(owner_).approve(caller.address, parseShares(test.ownerAllowance))
+
+                // hold before states
+                var ownerSharesBefore = await longToken.balanceOf(owner_.address)
+                var receiverAssetsBefore = await weth.balanceOf(receiver.address)
+                var totalAssetsBefore = await longToken.totalAssets()
+                var totalSharesBefore = await longToken.totalSupply()
+
+                // change market allowance
+                if (test.isMarketAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
+                }
+
+                // caller previews and redeems
+                var redeemShares = parseShares(test.redeemShares)
+                var previewSubject = longToken.connect(caller).previewRedeem(redeemShares)
+                var redeemSubject = longToken.connect(caller).redeem(redeemShares, receiver.address, owner_.address)
+
+                // assert
+                if (test.revertedWith !== void 0) {
+                    // preview
+                    if (test.revertedWithPreview !== void 0) {
+                        await expect(previewSubject).to.revertedWith(test.revertedWithPreview)
+                    } else {
+                        expect(await previewSubject).to.equal(parseAssets(test.withdrawnAssetsPreview))
+                    }
+                    // redeem
+                    await expect(redeemSubject).to.revertedWith(test.revertedWith)
+                } else {
+                    var withdrawnAssets = parseShares(test.withdrawnAssets)
+                    // event
+                    expect(await redeemSubject)
+                        .to.emit(longToken, "Withdraw")
+                        .withArgs(caller.address, receiver.address, owner.address, redeemShares, withdrawnAssets)
+
+                    // share
+                    expect(await longToken.totalSupply()).to.eq(totalSharesBefore.sub(redeemShares))
+                    expect(await longToken.balanceOf(owner_.address)).to.eq(ownerSharesBefore.sub(redeemShares))
+
+                    // asset
+                    expect(await longToken.totalAssets()).to.lt(totalAssetsBefore)
+                    expect(await weth.balanceOf(receiver.address)).to.eq(receiverAssetsBefore.add(withdrawnAssets))
+
+                    // preview >= burned
+                    expect(await previewSubject).to.eq(parseShares(test.withdrawnAssetsPreview))
+                }
+            })
+        })
+    })
+})

--- a/test/longToken/redeem.test.ts
+++ b/test/longToken/redeem.test.ts
@@ -109,7 +109,7 @@ describe("PerpdexLongToken redeem", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // init pool
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
                 await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
 
@@ -250,7 +250,7 @@ describe("PerpdexLongToken redeem", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // pool
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
                 var caller = toWallet(test.caller)
                 var owner_ = toWallet(test.owner)

--- a/test/longToken/redeem.test.ts
+++ b/test/longToken/redeem.test.ts
@@ -68,6 +68,10 @@ describe("PerpdexLongToken redeem", async () => {
                 alice = fixture.alice
                 bob = fixture.bob
                 charlie = fixture.charlie
+
+                await weth.connect(owner).deposit({
+                    value: ethers.utils.parseEther("200"),
+                })
             })
 
             describe("maxRedeem", async () => {

--- a/test/longToken/redeem.test.ts
+++ b/test/longToken/redeem.test.ts
@@ -72,7 +72,7 @@ describe("PerpdexLongToken redeem", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: false,
+                isMarketAllowed: false,
                 depositAssets: "10",
                 expected: "0",
             },
@@ -82,7 +82,7 @@ describe("PerpdexLongToken redeem", async () => {
                     base: "0",
                     quote: "0",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 expected: "0",
             },
@@ -92,7 +92,7 @@ describe("PerpdexLongToken redeem", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 expected: "9.990009990009990009",
             },
@@ -102,7 +102,7 @@ describe("PerpdexLongToken redeem", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "0",
                 expected: "0",
             },
@@ -111,13 +111,13 @@ describe("PerpdexLongToken redeem", async () => {
                 // init pool
                 await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
-                await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
 
                 // alice deposits
                 await weth.connect(owner).mint(alice.address, parseAssets(test.depositAssets))
 
                 // deposit only when market is allowed and pool has liquidity
-                if (test.isMarkeAllowed && test.pool.base !== "0" && test.depositAssets !== "0") {
+                if (test.isMarketAllowed && test.pool.base !== "0" && test.depositAssets !== "0") {
                     await longToken.connect(alice).deposit(parseAssets(test.depositAssets), alice.address)
                 }
 
@@ -141,7 +141,7 @@ describe("PerpdexLongToken redeem", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: false,
+                isMarketAllowed: false,
                 depositAssets: "10",
                 redeemShares: "5",
                 ownerAllowance: "0",
@@ -157,7 +157,7 @@ describe("PerpdexLongToken redeem", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 redeemShares: "0",
                 ownerAllowance: "0",
@@ -173,7 +173,7 @@ describe("PerpdexLongToken redeem", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 redeemShares: "20",
                 ownerAllowance: "0",
@@ -189,7 +189,7 @@ describe("PerpdexLongToken redeem", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 redeemShares: "9.9",
                 ownerAllowance: "0",
@@ -205,7 +205,7 @@ describe("PerpdexLongToken redeem", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 redeemShares: "9.9",
                 ownerAllowance: "0",
@@ -221,7 +221,7 @@ describe("PerpdexLongToken redeem", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 redeemShares: "9.9",
                 ownerAllowance: "9.9",
@@ -237,7 +237,7 @@ describe("PerpdexLongToken redeem", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 redeemShares: "9.9",
                 ownerAllowance: "9.9",
@@ -271,8 +271,8 @@ describe("PerpdexLongToken redeem", async () => {
                 var totalSharesBefore = await longToken.totalSupply()
 
                 // change market allowance
-                if (test.isMarkeAllowed !== void 0) {
-                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                if (test.isMarketAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
                 }
 
                 // caller previews and redeems

--- a/test/longToken/redeem.test.ts
+++ b/test/longToken/redeem.test.ts
@@ -22,23 +22,6 @@ describe("PerpdexLongToken redeem", async () => {
     let bob: Wallet
     let charlie: Wallet
 
-    beforeEach(async () => {
-        fixture = await loadFixture(createPerpdexExchangeFixture())
-
-        longToken = fixture.perpdexLongToken
-        longTokenDecimals = await longToken.decimals()
-        market = fixture.perpdexMarket
-        exchange = fixture.perpdexExchange
-
-        weth = fixture.weth
-        wethDecimals = await weth.decimals()
-
-        owner = fixture.owner
-        alice = fixture.alice
-        bob = fixture.bob
-        charlie = fixture.charlie
-    })
-
     function parseAssets(amount: string) {
         return parseUnits(amount, wethDecimals)
     }
@@ -59,255 +42,297 @@ describe("PerpdexLongToken redeem", async () => {
         }
     }
 
-    describe("maxRedeem", async () => {
-        beforeEach(async () => {
-            // alice approve longToken of max assets
-            await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
-            await weth.approveForce(longToken.address, exchange.address, ethers.constants.MaxUint256)
-        })
-        ;[
-            {
-                title: "returns 0 when market is not allowed",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: false,
-                depositAssets: "10",
-                expected: "0",
-            },
-            {
-                title: "returns 0 when pool liquidity is zero",
-                pool: {
-                    base: "0",
-                    quote: "0",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                expected: "0",
-            },
-            {
-                title: "returns owner's shares",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                expected: "9.990009990009990009",
-            },
-            {
-                title: "returns owner's 0 shares",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "0",
-                expected: "0",
-            },
-        ].forEach(test => {
-            it(test.title, async () => {
-                // init pool
-                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+    ;[
+        {
+            settlementToken: "weth",
+            wethDecimals: 18,
+        },
+        {
+            settlementToken: "ETH",
+            wethDecimals: 18,
+        },
+    ].forEach(fixtureParams => {
+        describe(JSON.stringify(fixtureParams), () => {
+            beforeEach(async () => {
+                fixture = await loadFixture(createPerpdexExchangeFixture(fixtureParams))
 
-                await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
+                longToken = fixture.perpdexLongToken
+                longTokenDecimals = await longToken.decimals()
+                market = fixture.perpdexMarket
+                exchange = fixture.perpdexExchange
 
-                // alice deposits
-                await weth.connect(owner).mint(alice.address, parseAssets(test.depositAssets))
+                weth = fixture.weth
+                wethDecimals = await weth.decimals()
 
-                // deposit only when market is allowed and pool has liquidity
-                if (test.isMarketAllowed && test.pool.base !== "0" && test.depositAssets !== "0") {
-                    await longToken.connect(alice).deposit(parseAssets(test.depositAssets), alice.address)
-                }
-
-                // alice maxRedeem
-                expect(await longToken.connect(alice).maxRedeem(alice.address)).to.eq(parseAssets(test.expected))
+                owner = fixture.owner
+                alice = fixture.alice
+                bob = fixture.bob
+                charlie = fixture.charlie
             })
-        })
-    })
 
-    describe("previewRedeem and redeem", async () => {
-        beforeEach(async () => {
-            // alice approve longToken of max assets
-            await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
-            // bob approve longToken of max assets
-            await weth.approveForce(bob.address, longToken.address, ethers.constants.MaxUint256)
-        })
-        ;[
-            {
-                title: "both reverts when market is not allowed",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: false,
-                depositAssets: "10",
-                redeemShares: "5",
-                ownerAllowance: "0",
-                caller: "alice",
-                owner: "alice",
-                receiver: "alice",
-                revertedWithPreview: "PE_CMA: market not allowed",
-                revertedWith: "PE_CMA: market not allowed", // maxWithdraw == 0
-            },
-            {
-                title: "both reverts when shares is zero",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                redeemShares: "0",
-                ownerAllowance: "0",
-                caller: "alice",
-                owner: "alice",
-                receiver: "alice",
-                revertedWithPreview: "PL_SD: output is zero",
-                revertedWith: "PL_SD: output is zero'",
-            },
-            {
-                title: "redeem reverts and preview succeeds when shares is more than max",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                redeemShares: "20",
-                ownerAllowance: "0",
-                caller: "alice",
-                owner: "alice",
-                receiver: "alice",
-                withdrawnAssetsPreview: "19.999980039960000079",
-                revertedWith: "ERC20: burn amount exceeds balance",
-            },
-            {
-                title: "redeem reverts and preview succeeds when alice redeems unapproved bob's shares",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                redeemShares: "9.9",
-                ownerAllowance: "0",
-                caller: "alice",
-                owner: "bob",
-                receiver: "alice",
-                withdrawnAssetsPreview: "9.909989199802887336",
-                revertedWith: "ERC20: transfer amount exceeds allowance",
-            },
-            {
-                title: "succeeds when alice redeems her shares",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                redeemShares: "9.9",
-                ownerAllowance: "0",
-                caller: "alice",
-                owner: "alice",
-                receiver: "alice",
-                withdrawnAssetsPreview: "9.909989199802887336",
-                withdrawnAssets: "9.909989199802887336",
-            },
-            {
-                title: "succeeds when alice redeems approved bob's shares to alice",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                redeemShares: "9.9",
-                ownerAllowance: "9.9",
-                caller: "alice",
-                owner: "bob",
-                receiver: "alice",
-                withdrawnAssetsPreview: "9.909989199802887336",
-                withdrawnAssets: "9.909989199802887336",
-            },
-            {
-                title: "succeeds when alice redeems approved bob's shares to charlie",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                redeemShares: "9.9",
-                ownerAllowance: "9.9",
-                caller: "alice",
-                owner: "bob",
-                receiver: "charlie",
-                withdrawnAssetsPreview: "9.909989199802887336",
-                withdrawnAssets: "9.909989199802887336",
-            },
-        ].forEach(test => {
-            it(test.title, async () => {
-                // pool
-                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+            describe("maxRedeem", async () => {
+                beforeEach(async () => {
+                    // alice approve longToken of max assets
+                    await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
+                    await weth.approveForce(longToken.address, exchange.address, ethers.constants.MaxUint256)
+                })
+                ;[
+                    {
+                        title: "returns 0 when market is not allowed",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: false,
+                        depositAssets: "10",
+                        expected: "0",
+                    },
+                    {
+                        title: "returns 0 when pool liquidity is zero",
+                        pool: {
+                            base: "0",
+                            quote: "0",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        expected: "0",
+                    },
+                    {
+                        title: "returns owner's shares",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        expected: "9.990009990009990009",
+                    },
+                    {
+                        title: "returns owner's 0 shares",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "0",
+                        expected: "0",
+                    },
+                ].forEach(test => {
+                    it(test.title, async () => {
+                        // init pool
+                        await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
-                var caller = toWallet(test.caller)
-                var owner_ = toWallet(test.owner)
-                var receiver = toWallet(test.receiver)
+                        await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
 
-                // owner_ deposit
-                var depositAssets = parseAssets(test.depositAssets)
-                await weth.connect(owner).mint(owner_.address, depositAssets)
-                await longToken.connect(owner_).deposit(parseAssets(test.depositAssets), owner_.address)
+                        // alice deposits
+                        await weth.connect(owner).mint(alice.address, parseAssets(test.depositAssets))
 
-                // owner_ approves caller
-                await longToken.connect(owner_).approve(caller.address, parseShares(test.ownerAllowance))
+                        // deposit only when market is allowed and pool has liquidity
+                        if (test.isMarketAllowed && test.pool.base !== "0" && test.depositAssets !== "0") {
+                            await longToken.connect(alice).deposit(parseAssets(test.depositAssets), alice.address)
+                        }
 
-                // hold before states
-                var ownerSharesBefore = await longToken.balanceOf(owner_.address)
-                var receiverAssetsBefore = await weth.balanceOf(receiver.address)
-                var totalAssetsBefore = await longToken.totalAssets()
-                var totalSharesBefore = await longToken.totalSupply()
+                        // alice maxRedeem
+                        expect(await longToken.connect(alice).maxRedeem(alice.address)).to.eq(
+                            parseAssets(test.expected),
+                        )
+                    })
+                })
+            })
 
-                // change market allowance
-                if (test.isMarketAllowed !== void 0) {
-                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
-                }
+            describe("previewRedeem and redeem", async () => {
+                beforeEach(async () => {
+                    // alice approve longToken of max assets
+                    await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
+                    // bob approve longToken of max assets
+                    await weth.approveForce(bob.address, longToken.address, ethers.constants.MaxUint256)
+                })
+                ;[
+                    {
+                        title: "both reverts when market is not allowed",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: false,
+                        depositAssets: "10",
+                        redeemShares: "5",
+                        ownerAllowance: "0",
+                        caller: "alice",
+                        owner: "alice",
+                        receiver: "alice",
+                        revertedWithPreview: "PE_CMA: market not allowed",
+                        revertedWith: "PE_CMA: market not allowed", // maxWithdraw == 0
+                    },
+                    {
+                        title: "both reverts when shares is zero",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        redeemShares: "0",
+                        ownerAllowance: "0",
+                        caller: "alice",
+                        owner: "alice",
+                        receiver: "alice",
+                        revertedWithPreview: "PL_SD: output is zero",
+                        revertedWith: "PL_SD: output is zero'",
+                    },
+                    {
+                        title: "redeem reverts and preview succeeds when shares is more than max",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        redeemShares: "20",
+                        ownerAllowance: "0",
+                        caller: "alice",
+                        owner: "alice",
+                        receiver: "alice",
+                        withdrawnAssetsPreview: "19.999980039960000079",
+                        revertedWith: "ERC20: burn amount exceeds balance",
+                    },
+                    {
+                        title: "redeem reverts and preview succeeds when alice redeems unapproved bob's shares",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        redeemShares: "9.9",
+                        ownerAllowance: "0",
+                        caller: "alice",
+                        owner: "bob",
+                        receiver: "alice",
+                        withdrawnAssetsPreview: "9.909989199802887336",
+                        revertedWith: "ERC20: transfer amount exceeds allowance",
+                    },
+                    {
+                        title: "succeeds when alice redeems her shares",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        redeemShares: "9.9",
+                        ownerAllowance: "0",
+                        caller: "alice",
+                        owner: "alice",
+                        receiver: "alice",
+                        withdrawnAssetsPreview: "9.909989199802887336",
+                        withdrawnAssets: "9.909989199802887336",
+                    },
+                    {
+                        title: "succeeds when alice redeems approved bob's shares to alice",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        redeemShares: "9.9",
+                        ownerAllowance: "9.9",
+                        caller: "alice",
+                        owner: "bob",
+                        receiver: "alice",
+                        withdrawnAssetsPreview: "9.909989199802887336",
+                        withdrawnAssets: "9.909989199802887336",
+                    },
+                    {
+                        title: "succeeds when alice redeems approved bob's shares to charlie",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        redeemShares: "9.9",
+                        ownerAllowance: "9.9",
+                        caller: "alice",
+                        owner: "bob",
+                        receiver: "charlie",
+                        withdrawnAssetsPreview: "9.909989199802887336",
+                        withdrawnAssets: "9.909989199802887336",
+                    },
+                ].forEach(test => {
+                    it(test.title, async () => {
+                        // pool
+                        await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
-                // caller previews and redeems
-                var redeemShares = parseShares(test.redeemShares)
-                var previewSubject = longToken.connect(caller).previewRedeem(redeemShares)
-                var redeemSubject = longToken.connect(caller).redeem(redeemShares, receiver.address, owner_.address)
+                        var caller = toWallet(test.caller)
+                        var owner_ = toWallet(test.owner)
+                        var receiver = toWallet(test.receiver)
 
-                // assert
-                if (test.revertedWith !== void 0) {
-                    // preview
-                    if (test.revertedWithPreview !== void 0) {
-                        await expect(previewSubject).to.revertedWith(test.revertedWithPreview)
-                    } else {
-                        expect(await previewSubject).to.equal(parseAssets(test.withdrawnAssetsPreview))
-                    }
-                    // redeem
-                    await expect(redeemSubject).to.revertedWith(test.revertedWith)
-                } else {
-                    var withdrawnAssets = parseShares(test.withdrawnAssets)
-                    // event
-                    expect(await redeemSubject)
-                        .to.emit(longToken, "Withdraw")
-                        .withArgs(caller.address, receiver.address, owner.address, redeemShares, withdrawnAssets)
+                        // owner_ deposit
+                        var depositAssets = parseAssets(test.depositAssets)
+                        await weth.connect(owner).mint(owner_.address, depositAssets)
+                        await longToken.connect(owner_).deposit(parseAssets(test.depositAssets), owner_.address)
 
-                    // share
-                    expect(await longToken.totalSupply()).to.eq(totalSharesBefore.sub(redeemShares))
-                    expect(await longToken.balanceOf(owner_.address)).to.eq(ownerSharesBefore.sub(redeemShares))
+                        // owner_ approves caller
+                        await longToken.connect(owner_).approve(caller.address, parseShares(test.ownerAllowance))
 
-                    // asset
-                    expect(await longToken.totalAssets()).to.lt(totalAssetsBefore)
-                    expect(await weth.balanceOf(receiver.address)).to.eq(receiverAssetsBefore.add(withdrawnAssets))
+                        // hold before states
+                        var ownerSharesBefore = await longToken.balanceOf(owner_.address)
+                        var receiverAssetsBefore = await weth.balanceOf(receiver.address)
+                        var totalAssetsBefore = await longToken.totalAssets()
+                        var totalSharesBefore = await longToken.totalSupply()
 
-                    // preview >= burned
-                    expect(await previewSubject).to.eq(parseShares(test.withdrawnAssetsPreview))
-                }
+                        // change market allowance
+                        if (test.isMarketAllowed !== void 0) {
+                            await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
+                        }
+
+                        // caller previews and redeems
+                        var redeemShares = parseShares(test.redeemShares)
+                        var previewSubject = longToken.connect(caller).previewRedeem(redeemShares)
+                        var redeemSubject = longToken
+                            .connect(caller)
+                            .redeem(redeemShares, receiver.address, owner_.address)
+
+                        // assert
+                        if (test.revertedWith !== void 0) {
+                            // preview
+                            if (test.revertedWithPreview !== void 0) {
+                                await expect(previewSubject).to.revertedWith(test.revertedWithPreview)
+                            } else {
+                                expect(await previewSubject).to.equal(parseAssets(test.withdrawnAssetsPreview))
+                            }
+                            // redeem
+                            await expect(redeemSubject).to.revertedWith(test.revertedWith)
+                        } else {
+                            var withdrawnAssets = parseShares(test.withdrawnAssets)
+                            // event
+                            expect(await redeemSubject)
+                                .to.emit(longToken, "Withdraw")
+                                .withArgs(
+                                    caller.address,
+                                    receiver.address,
+                                    owner.address,
+                                    redeemShares,
+                                    withdrawnAssets,
+                                )
+
+                            // share
+                            expect(await longToken.totalSupply()).to.eq(totalSharesBefore.sub(redeemShares))
+                            expect(await longToken.balanceOf(owner_.address)).to.eq(ownerSharesBefore.sub(redeemShares))
+
+                            // asset
+                            expect(await longToken.totalAssets()).to.lt(totalAssetsBefore)
+                            expect(await weth.balanceOf(receiver.address)).to.eq(
+                                receiverAssetsBefore.add(withdrawnAssets),
+                            )
+
+                            // preview >= burned
+                            expect(await previewSubject).to.eq(parseShares(test.withdrawnAssetsPreview))
+                        }
+                    })
+                })
             })
         })
     })

--- a/test/longToken/redeem.test.ts
+++ b/test/longToken/redeem.test.ts
@@ -109,7 +109,7 @@ describe("PerpdexLongToken redeem", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // init pool
-                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
                 await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
 
@@ -250,7 +250,7 @@ describe("PerpdexLongToken redeem", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // pool
-                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
                 var caller = toWallet(test.caller)
                 var owner_ = toWallet(test.owner)

--- a/test/longToken/withdraw.eth.test.ts
+++ b/test/longToken/withdraw.eth.test.ts
@@ -7,7 +7,7 @@ import { PerpdexLongToken, TestERC20, TestPerpdexExchange, TestPerpdexMarket } f
 import { createPerpdexExchangeFixture } from "./fixtures"
 import { initPool } from "./helpers"
 
-describe("PerpdexLongToken withdraw", async () => {
+describe("PerpdexLongToken withdraw ETH", async () => {
     let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
     let fixture
 

--- a/test/longToken/withdraw.eth.test.ts
+++ b/test/longToken/withdraw.eth.test.ts
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { expect } from "chai"
+import { Wallet } from "ethers"
+import { parseUnits } from "ethers/lib/utils"
+import { ethers, waffle } from "hardhat"
+import { PerpdexLongToken, TestERC20, TestPerpdexExchange, TestPerpdexMarket } from "../../typechain"
+import { createPerpdexExchangeFixture } from "./fixtures"
+import { initPool } from "./helpers"
+
+describe("PerpdexLongToken withdraw", async () => {
+    let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+    let fixture
+
+    let longToken: PerpdexLongToken
+    let longTokenDecimals: number
+    let market: TestPerpdexMarket
+    let exchange: TestPerpdexExchange
+    let weth: TestERC20
+    let wethDecimals: number
+    let owner: Wallet
+    let alice: Wallet
+    let bob: Wallet
+    let charlie: Wallet
+
+    beforeEach(async () => {
+        fixture = await loadFixture(createPerpdexExchangeFixture({ settlementToken: "ETH", wethDecimals: 18 }))
+
+        longToken = fixture.perpdexLongToken
+        longTokenDecimals = await longToken.decimals()
+        market = fixture.perpdexMarket
+        exchange = fixture.perpdexExchange
+
+        weth = fixture.weth
+        wethDecimals = await weth.decimals()
+
+        owner = fixture.owner
+        alice = fixture.alice
+        bob = fixture.bob
+        charlie = fixture.charlie
+    })
+
+    function parseAssets(amount: string) {
+        return parseUnits(amount, wethDecimals)
+    }
+
+    function parseShares(amount: string) {
+        return parseUnits(amount, longTokenDecimals)
+    }
+
+    function toWallet(who: string) {
+        if (who === "alice") {
+            return alice
+        }
+        if (who === "bob") {
+            return bob
+        }
+        if (who === "charlie") {
+            return charlie
+        }
+    }
+
+    describe("withdrawETH", async () => {
+        beforeEach(async () => {
+            // alice approve longToken of max assets
+            await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
+            // bob approve longToken of max assets
+            await weth.approveForce(bob.address, longToken.address, ethers.constants.MaxUint256)
+        })
+        ;[
+            {
+                title: "both reverts when market is not allowed",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: false,
+                depositAssets: "10",
+                withdrawAssets: "5",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "alice",
+                receiver: "alice",
+                revertedWithPreview: "PE_CMA: market not allowed",
+                revertedWith: "PE_CMA: market not allowed", // maxWithdraw == 0
+            },
+            {
+                title: "both reverts when assets is zero",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                withdrawAssets: "0",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "alice",
+                receiver: "alice",
+                revertedWithPreview: "PL_SD: output is zero",
+                revertedWith: "PL_SD: output is zero",
+            },
+            {
+                title: "withdraw reverts and preview succeeds when assets is more than max",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                withdrawAssets: "20",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "alice",
+                receiver: "alice",
+                burnedSharesPreview: "20.000020000020000021",
+                revertedWith: "ERC20: burn amount exceeds balance",
+            },
+            {
+                title: "withdraw reverts and preview succeeds when alice withdraws unapproved bob's assets",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                withdrawAssets: "9.9",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "bob",
+                receiver: "alice",
+                burnedSharesPreview: "9.890010989999990110",
+                revertedWith: "ERC20: transfer amount exceeds allowance",
+            },
+            {
+                title: "succeeds when alice withdraws her assets",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                withdrawAssets: "9.9",
+                ownerAllowance: "0",
+                caller: "alice",
+                owner: "alice",
+                receiver: "alice",
+                burnedSharesPreview: "9.890010989999990110",
+                burnedShares: "9.890010989999990110",
+            },
+            {
+                title: "succeeds when alice withdraws approved bob's assets to alice",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                withdrawAssets: "9.9",
+                ownerAllowance: "9.891",
+                caller: "alice",
+                owner: "bob",
+                receiver: "alice",
+                burnedSharesPreview: "9.890010989999990110",
+                burnedShares: "9.890010989999990110",
+            },
+            {
+                title: "succeeds when alice withdraws approved bob's assets to charlie",
+                pool: {
+                    base: "10000",
+                    quote: "10000",
+                },
+                isMarketAllowed: true,
+                depositAssets: "10",
+                withdrawAssets: "9.9",
+                ownerAllowance: "9.891",
+                caller: "alice",
+                owner: "bob",
+                receiver: "charlie",
+                burnedSharesPreview: "9.890010989999990110",
+                burnedShares: "9.890010989999990110",
+            },
+        ].forEach(test => {
+            it(test.title, async () => {
+                // pool
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+
+                var caller = toWallet(test.caller)
+                var owner_ = toWallet(test.owner)
+                var receiver = toWallet(test.receiver)
+
+                // owner_ deposit
+                await longToken.connect(owner_).depositETH(owner_.address, { value: parseAssets(test.depositAssets) })
+
+                // owner_ approves caller
+                await longToken.connect(owner_).approve(caller.address, parseShares(test.ownerAllowance))
+
+                // hold before states
+                var ownerSharesBefore = await longToken.balanceOf(owner_.address)
+                var receiverAssetsBefore = await weth.balanceOf(receiver.address)
+                var totalAssetsBefore = await longToken.totalAssets()
+                var totalSharesBefore = await longToken.totalSupply()
+
+                // change market allowance
+                if (test.isMarketAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
+                }
+
+                // caller previews and withdraws
+                var withdrawAssets = parseAssets(test.withdrawAssets)
+                var previewSubject = longToken.connect(caller).previewWithdraw(withdrawAssets)
+                var withdrawSubject = longToken
+                    .connect(caller)
+                    .withdrawETH(withdrawAssets, receiver.address, owner_.address)
+
+                // assert withdraw
+                if (test.revertedWith !== void 0) {
+                    // preview
+                    if (test.revertedWithPreview !== void 0) {
+                        await expect(previewSubject).to.revertedWith(test.revertedWithPreview)
+                    } else {
+                        expect(await previewSubject).to.equal(parseShares(test.burnedSharesPreview))
+                    }
+                    // withdraw
+                    await expect(withdrawSubject).to.revertedWith(test.revertedWith)
+                } else {
+                    var burnedShares = parseShares(test.burnedShares)
+                    // event
+                    expect(await withdrawSubject)
+                        .to.emit(longToken, "Withdraw")
+                        .withArgs(caller.address, receiver.address, owner.address, withdrawAssets, burnedShares)
+
+                    // share
+                    expect(await longToken.totalSupply()).to.eq(totalSharesBefore.sub(burnedShares))
+                    expect(await longToken.balanceOf(owner_.address)).to.eq(ownerSharesBefore.sub(burnedShares))
+
+                    // asset
+                    expect(await longToken.totalAssets()).to.lt(totalAssetsBefore)
+                    expect(await withdrawSubject).to.changeEtherBalance(caller, withdrawAssets)
+
+                    // preview >= burned
+                    expect(await previewSubject).to.eq(parseShares(test.burnedSharesPreview))
+                }
+            })
+        })
+    })
+})

--- a/test/longToken/withdraw.test.ts
+++ b/test/longToken/withdraw.test.ts
@@ -99,7 +99,7 @@ describe("PerpdexLongToken withdraw", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // init pool
-                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
                 // alice deposits
                 await weth.connect(owner).mint(alice.address, parseAssets(test.depositAssets))
@@ -250,7 +250,7 @@ describe("PerpdexLongToken withdraw", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // pool
-                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
                 var caller = toWallet(test.caller)
                 var owner_ = toWallet(test.owner)

--- a/test/longToken/withdraw.test.ts
+++ b/test/longToken/withdraw.test.ts
@@ -318,9 +318,14 @@ describe("PerpdexLongToken withdraw", async () => {
 
                             // asset
                             expect(await longToken.totalAssets()).to.lt(totalAssetsBefore)
-                            expect(await weth.balanceOf(receiver.address)).to.eq(
-                                receiverAssetsBefore.add(withdrawAssets),
-                            )
+
+                            if (fixtureParams.settlementToken == "ETH") {
+                                expect(await withdrawSubject).to.changeEtherBalance(caller, withdrawAssets)
+                            } else {
+                                expect(await weth.balanceOf(receiver.address)).to.eq(
+                                    receiverAssetsBefore.add(withdrawAssets),
+                                )
+                            }
 
                             // preview >= burned
                             expect(await previewSubject).to.eq(parseShares(test.burnedSharesPreview))

--- a/test/longToken/withdraw.test.ts
+++ b/test/longToken/withdraw.test.ts
@@ -94,7 +94,7 @@ describe("PerpdexLongToken withdraw", async () => {
                 },
                 isMarketAllowed: true,
                 depositAssets: "10",
-                expected: "10.009999999999999999",
+                expected: "9.980019990000000009",
             },
         ].forEach(test => {
             it(test.title, async () => {

--- a/test/longToken/withdraw.test.ts
+++ b/test/longToken/withdraw.test.ts
@@ -94,7 +94,7 @@ describe("PerpdexLongToken withdraw", async () => {
                 },
                 isMarketAllowed: true,
                 depositAssets: "10",
-                expected: "9.980019990000000009",
+                expected: "9.999999999999999999",
             },
         ].forEach(test => {
             it(test.title, async () => {

--- a/test/longToken/withdraw.test.ts
+++ b/test/longToken/withdraw.test.ts
@@ -71,7 +71,7 @@ describe("PerpdexLongToken withdraw", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: false,
+                isMarketAllowed: false,
                 depositAssets: "10",
                 removeLiquidity: 0,
                 expected: "0",
@@ -82,7 +82,7 @@ describe("PerpdexLongToken withdraw", async () => {
                     base: "0",
                     quote: "0",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "0",
                 expected: "0", // math error without message
             },
@@ -92,7 +92,7 @@ describe("PerpdexLongToken withdraw", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 expected: "10.009999999999999999",
             },
@@ -108,7 +108,7 @@ describe("PerpdexLongToken withdraw", async () => {
                     await longToken.connect(alice).deposit(parseAssets(test.depositAssets), alice.address)
                 }
 
-                await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
 
                 expect(await longToken.maxWithdraw(alice.address)).to.eq(parseAssets(test.expected))
             })
@@ -129,7 +129,7 @@ describe("PerpdexLongToken withdraw", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: false,
+                isMarketAllowed: false,
                 depositAssets: "10",
                 withdrawAssets: "5",
                 ownerAllowance: "0",
@@ -145,7 +145,7 @@ describe("PerpdexLongToken withdraw", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 withdrawAssets: "0",
                 ownerAllowance: "0",
@@ -161,7 +161,7 @@ describe("PerpdexLongToken withdraw", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 withdrawAssets: "20",
                 ownerAllowance: "0",
@@ -177,7 +177,7 @@ describe("PerpdexLongToken withdraw", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 withdrawAssets: "9.9",
                 ownerAllowance: "0",
@@ -193,7 +193,7 @@ describe("PerpdexLongToken withdraw", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 withdrawAssets: "9.9",
                 ownerAllowance: "0",
@@ -209,7 +209,7 @@ describe("PerpdexLongToken withdraw", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 withdrawAssets: "9.9",
                 ownerAllowance: "9.891",
@@ -225,7 +225,7 @@ describe("PerpdexLongToken withdraw", async () => {
                     base: "10000",
                     quote: "10000",
                 },
-                isMarkeAllowed: true,
+                isMarketAllowed: true,
                 depositAssets: "10",
                 withdrawAssets: "9.9",
                 ownerAllowance: "9.891",
@@ -259,8 +259,8 @@ describe("PerpdexLongToken withdraw", async () => {
                 var totalSharesBefore = await longToken.totalSupply()
 
                 // change market allowance
-                if (test.isMarkeAllowed !== void 0) {
-                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarkeAllowed)
+                if (test.isMarketAllowed !== void 0) {
+                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
                 }
 
                 // caller previews and withdraws

--- a/test/longToken/withdraw.test.ts
+++ b/test/longToken/withdraw.test.ts
@@ -22,23 +22,6 @@ describe("PerpdexLongToken withdraw", async () => {
     let bob: Wallet
     let charlie: Wallet
 
-    beforeEach(async () => {
-        fixture = await loadFixture(createPerpdexExchangeFixture())
-
-        longToken = fixture.perpdexLongToken
-        longTokenDecimals = await longToken.decimals()
-        market = fixture.perpdexMarket
-        exchange = fixture.perpdexExchange
-
-        weth = fixture.weth
-        wethDecimals = await weth.decimals()
-
-        owner = fixture.owner
-        alice = fixture.alice
-        bob = fixture.bob
-        charlie = fixture.charlie
-    })
-
     function parseAssets(amount: string) {
         return parseUnits(amount, wethDecimals)
     }
@@ -59,257 +42,291 @@ describe("PerpdexLongToken withdraw", async () => {
         }
     }
 
-    describe("maxWithdraw", async () => {
-        beforeEach(async () => {
-            // alice approve longToken of max assets
-            await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
-        })
-        ;[
-            {
-                title: "returns 0 when market is not allowed",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: false,
-                depositAssets: "10",
-                removeLiquidity: 0,
-                expected: "0",
-            },
-            {
-                title: "returns 0 when liquidity is zero",
-                pool: {
-                    base: "0",
-                    quote: "0",
-                },
-                isMarketAllowed: true,
-                depositAssets: "0",
-                expected: "0", // math error without message
-            },
-            {
-                title: "success case",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                expected: "9.999999999999999999",
-            },
-        ].forEach(test => {
-            it(test.title, async () => {
-                // init pool
-                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+    ;[
+        {
+            settlementToken: "weth",
+            wethDecimals: 18,
+        },
+        {
+            settlementToken: "ETH",
+            wethDecimals: 18,
+        },
+    ].forEach(fixtureParams => {
+        describe(JSON.stringify(fixtureParams), () => {
+            beforeEach(async () => {
+                fixture = await loadFixture(createPerpdexExchangeFixture(fixtureParams))
 
-                // alice deposits
-                await weth.connect(owner).mint(alice.address, parseAssets(test.depositAssets))
+                longToken = fixture.perpdexLongToken
+                longTokenDecimals = await longToken.decimals()
+                market = fixture.perpdexMarket
+                exchange = fixture.perpdexExchange
 
-                if (test.pool.base !== "0" && test.depositAssets !== "0") {
-                    await longToken.connect(alice).deposit(parseAssets(test.depositAssets), alice.address)
-                }
+                weth = fixture.weth
+                wethDecimals = await weth.decimals()
 
-                await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
-
-                const maxWithdraw = await longToken.maxWithdraw(alice.address)
-                expect(maxWithdraw).to.eq(parseAssets(test.expected))
-
-                // check consistency
-                const previewSubject = longToken.connect(alice).previewWithdraw(maxWithdraw)
-                const withdrawSubject = longToken.connect(alice).withdraw(maxWithdraw, alice.address, alice.address)
-                if (maxWithdraw.gt(0)) {
-                    await expect(previewSubject).not.to.reverted
-                    await expect(withdrawSubject).not.to.reverted
-                } else {
-                    await expect(previewSubject).to.reverted
-                    await expect(withdrawSubject).to.reverted
-                }
+                owner = fixture.owner
+                alice = fixture.alice
+                bob = fixture.bob
+                charlie = fixture.charlie
             })
-        })
-    })
 
-    describe("previewWithdraw and withdraw", async () => {
-        beforeEach(async () => {
-            // alice approve longToken of max assets
-            await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
-            // bob approve longToken of max assets
-            await weth.approveForce(bob.address, longToken.address, ethers.constants.MaxUint256)
-        })
-        ;[
-            {
-                title: "both reverts when market is not allowed",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: false,
-                depositAssets: "10",
-                withdrawAssets: "5",
-                ownerAllowance: "0",
-                caller: "alice",
-                owner: "alice",
-                receiver: "alice",
-                revertedWithPreview: "PE_CMA: market not allowed",
-                revertedWith: "PE_CMA: market not allowed", // maxWithdraw == 0
-            },
-            {
-                title: "both reverts when assets is zero",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                withdrawAssets: "0",
-                ownerAllowance: "0",
-                caller: "alice",
-                owner: "alice",
-                receiver: "alice",
-                revertedWithPreview: "PL_SD: output is zero",
-                revertedWith: "PL_SD: output is zero",
-            },
-            {
-                title: "withdraw reverts and preview succeeds when assets is more than max",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                withdrawAssets: "20",
-                ownerAllowance: "0",
-                caller: "alice",
-                owner: "alice",
-                receiver: "alice",
-                burnedSharesPreview: "20.000020000020000021",
-                revertedWith: "ERC20: burn amount exceeds balance",
-            },
-            {
-                title: "withdraw reverts and preview succeeds when alice withdraws unapproved bob's assets",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                withdrawAssets: "9.9",
-                ownerAllowance: "0",
-                caller: "alice",
-                owner: "bob",
-                receiver: "alice",
-                burnedSharesPreview: "9.890010989999990110",
-                revertedWith: "ERC20: transfer amount exceeds allowance",
-            },
-            {
-                title: "succeeds when alice withdraws her assets",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                withdrawAssets: "9.9",
-                ownerAllowance: "0",
-                caller: "alice",
-                owner: "alice",
-                receiver: "alice",
-                burnedSharesPreview: "9.890010989999990110",
-                burnedShares: "9.890010989999990110",
-            },
-            {
-                title: "succeeds when alice withdraws approved bob's assets to alice",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                withdrawAssets: "9.9",
-                ownerAllowance: "9.891",
-                caller: "alice",
-                owner: "bob",
-                receiver: "alice",
-                burnedSharesPreview: "9.890010989999990110",
-                burnedShares: "9.890010989999990110",
-            },
-            {
-                title: "succeeds when alice withdraws approved bob's assets to charlie",
-                pool: {
-                    base: "10000",
-                    quote: "10000",
-                },
-                isMarketAllowed: true,
-                depositAssets: "10",
-                withdrawAssets: "9.9",
-                ownerAllowance: "9.891",
-                caller: "alice",
-                owner: "bob",
-                receiver: "charlie",
-                burnedSharesPreview: "9.890010989999990110",
-                burnedShares: "9.890010989999990110",
-            },
-        ].forEach(test => {
-            it(test.title, async () => {
-                // pool
-                await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
+            describe("maxWithdraw", async () => {
+                beforeEach(async () => {
+                    // alice approve longToken of max assets
+                    await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
+                })
+                ;[
+                    {
+                        title: "returns 0 when market is not allowed",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: false,
+                        depositAssets: "10",
+                        removeLiquidity: 0,
+                        expected: "0",
+                    },
+                    {
+                        title: "returns 0 when liquidity is zero",
+                        pool: {
+                            base: "0",
+                            quote: "0",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "0",
+                        expected: "0", // math error without message
+                    },
+                    {
+                        title: "success case",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        expected: "9.999999999999999999",
+                    },
+                ].forEach(test => {
+                    it(test.title, async () => {
+                        // init pool
+                        await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
-                var caller = toWallet(test.caller)
-                var owner_ = toWallet(test.owner)
-                var receiver = toWallet(test.receiver)
+                        // alice deposits
+                        await weth.connect(owner).mint(alice.address, parseAssets(test.depositAssets))
 
-                // owner_ deposit
-                var depositAssets = parseAssets(test.depositAssets)
-                await weth.connect(owner).mint(owner_.address, depositAssets)
-                await longToken.connect(owner_).deposit(parseAssets(test.depositAssets), owner_.address)
+                        if (test.pool.base !== "0" && test.depositAssets !== "0") {
+                            await longToken.connect(alice).deposit(parseAssets(test.depositAssets), alice.address)
+                        }
 
-                // owner_ approves caller
-                await longToken.connect(owner_).approve(caller.address, parseShares(test.ownerAllowance))
+                        await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
 
-                // hold before states
-                var ownerSharesBefore = await longToken.balanceOf(owner_.address)
-                var receiverAssetsBefore = await weth.balanceOf(receiver.address)
-                var totalAssetsBefore = await longToken.totalAssets()
-                var totalSharesBefore = await longToken.totalSupply()
+                        const maxWithdraw = await longToken.maxWithdraw(alice.address)
+                        expect(maxWithdraw).to.eq(parseAssets(test.expected))
 
-                // change market allowance
-                if (test.isMarketAllowed !== void 0) {
-                    await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
-                }
+                        // check consistency
+                        const previewSubject = longToken.connect(alice).previewWithdraw(maxWithdraw)
+                        const withdrawSubject = longToken
+                            .connect(alice)
+                            .withdraw(maxWithdraw, alice.address, alice.address)
+                        if (maxWithdraw.gt(0)) {
+                            await expect(previewSubject).not.to.reverted
+                            await expect(withdrawSubject).not.to.reverted
+                        } else {
+                            await expect(previewSubject).to.reverted
+                            await expect(withdrawSubject).to.reverted
+                        }
+                    })
+                })
+            })
 
-                // caller previews and withdraws
-                var withdrawAssets = parseAssets(test.withdrawAssets)
-                var previewSubject = longToken.connect(caller).previewWithdraw(withdrawAssets)
-                var withdrawSubject = longToken
-                    .connect(caller)
-                    .withdraw(withdrawAssets, receiver.address, owner_.address)
+            describe("previewWithdraw and withdraw", async () => {
+                beforeEach(async () => {
+                    // alice approve longToken of max assets
+                    await weth.approveForce(alice.address, longToken.address, ethers.constants.MaxUint256)
+                    // bob approve longToken of max assets
+                    await weth.approveForce(bob.address, longToken.address, ethers.constants.MaxUint256)
+                })
+                ;[
+                    {
+                        title: "both reverts when market is not allowed",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: false,
+                        depositAssets: "10",
+                        withdrawAssets: "5",
+                        ownerAllowance: "0",
+                        caller: "alice",
+                        owner: "alice",
+                        receiver: "alice",
+                        revertedWithPreview: "PE_CMA: market not allowed",
+                        revertedWith: "PE_CMA: market not allowed", // maxWithdraw == 0
+                    },
+                    {
+                        title: "both reverts when assets is zero",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        withdrawAssets: "0",
+                        ownerAllowance: "0",
+                        caller: "alice",
+                        owner: "alice",
+                        receiver: "alice",
+                        revertedWithPreview: "PL_SD: output is zero",
+                        revertedWith: "PL_SD: output is zero",
+                    },
+                    {
+                        title: "withdraw reverts and preview succeeds when assets is more than max",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        withdrawAssets: "20",
+                        ownerAllowance: "0",
+                        caller: "alice",
+                        owner: "alice",
+                        receiver: "alice",
+                        burnedSharesPreview: "20.000020000020000021",
+                        revertedWith: "ERC20: burn amount exceeds balance",
+                    },
+                    {
+                        title: "withdraw reverts and preview succeeds when alice withdraws unapproved bob's assets",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        withdrawAssets: "9.9",
+                        ownerAllowance: "0",
+                        caller: "alice",
+                        owner: "bob",
+                        receiver: "alice",
+                        burnedSharesPreview: "9.890010989999990110",
+                        revertedWith: "ERC20: transfer amount exceeds allowance",
+                    },
+                    {
+                        title: "succeeds when alice withdraws her assets",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        withdrawAssets: "9.9",
+                        ownerAllowance: "0",
+                        caller: "alice",
+                        owner: "alice",
+                        receiver: "alice",
+                        burnedSharesPreview: "9.890010989999990110",
+                        burnedShares: "9.890010989999990110",
+                    },
+                    {
+                        title: "succeeds when alice withdraws approved bob's assets to alice",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        withdrawAssets: "9.9",
+                        ownerAllowance: "9.891",
+                        caller: "alice",
+                        owner: "bob",
+                        receiver: "alice",
+                        burnedSharesPreview: "9.890010989999990110",
+                        burnedShares: "9.890010989999990110",
+                    },
+                    {
+                        title: "succeeds when alice withdraws approved bob's assets to charlie",
+                        pool: {
+                            base: "10000",
+                            quote: "10000",
+                        },
+                        isMarketAllowed: true,
+                        depositAssets: "10",
+                        withdrawAssets: "9.9",
+                        ownerAllowance: "9.891",
+                        caller: "alice",
+                        owner: "bob",
+                        receiver: "charlie",
+                        burnedSharesPreview: "9.890010989999990110",
+                        burnedShares: "9.890010989999990110",
+                    },
+                ].forEach(test => {
+                    it(test.title, async () => {
+                        // pool
+                        await initPool(fixture, parseShares(test.pool.base), parseShares(test.pool.quote))
 
-                // assert withdraw
-                if (test.revertedWith !== void 0) {
-                    // preview
-                    if (test.revertedWithPreview !== void 0) {
-                        await expect(previewSubject).to.revertedWith(test.revertedWithPreview)
-                    } else {
-                        expect(await previewSubject).to.equal(parseShares(test.burnedSharesPreview))
-                    }
-                    // withdraw
-                    await expect(withdrawSubject).to.revertedWith(test.revertedWith)
-                } else {
-                    var burnedShares = parseShares(test.burnedShares)
-                    // event
-                    expect(await withdrawSubject)
-                        .to.emit(longToken, "Withdraw")
-                        .withArgs(caller.address, receiver.address, owner.address, withdrawAssets, burnedShares)
+                        var caller = toWallet(test.caller)
+                        var owner_ = toWallet(test.owner)
+                        var receiver = toWallet(test.receiver)
 
-                    // share
-                    expect(await longToken.totalSupply()).to.eq(totalSharesBefore.sub(burnedShares))
-                    expect(await longToken.balanceOf(owner_.address)).to.eq(ownerSharesBefore.sub(burnedShares))
+                        // owner_ deposit
+                        var depositAssets = parseAssets(test.depositAssets)
+                        await weth.connect(owner).mint(owner_.address, depositAssets)
+                        await longToken.connect(owner_).deposit(parseAssets(test.depositAssets), owner_.address)
 
-                    // asset
-                    expect(await longToken.totalAssets()).to.lt(totalAssetsBefore)
-                    expect(await weth.balanceOf(receiver.address)).to.eq(receiverAssetsBefore.add(withdrawAssets))
+                        // owner_ approves caller
+                        await longToken.connect(owner_).approve(caller.address, parseShares(test.ownerAllowance))
 
-                    // preview >= burned
-                    expect(await previewSubject).to.eq(parseShares(test.burnedSharesPreview))
-                }
+                        // hold before states
+                        var ownerSharesBefore = await longToken.balanceOf(owner_.address)
+                        var receiverAssetsBefore = await weth.balanceOf(receiver.address)
+                        var totalAssetsBefore = await longToken.totalAssets()
+                        var totalSharesBefore = await longToken.totalSupply()
+
+                        // change market allowance
+                        if (test.isMarketAllowed !== void 0) {
+                            await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
+                        }
+
+                        // caller previews and withdraws
+                        var withdrawAssets = parseAssets(test.withdrawAssets)
+                        var previewSubject = longToken.connect(caller).previewWithdraw(withdrawAssets)
+                        var withdrawSubject = longToken
+                            .connect(caller)
+                            .withdraw(withdrawAssets, receiver.address, owner_.address)
+
+                        // assert withdraw
+                        if (test.revertedWith !== void 0) {
+                            // preview
+                            if (test.revertedWithPreview !== void 0) {
+                                await expect(previewSubject).to.revertedWith(test.revertedWithPreview)
+                            } else {
+                                expect(await previewSubject).to.equal(parseShares(test.burnedSharesPreview))
+                            }
+                            // withdraw
+                            await expect(withdrawSubject).to.revertedWith(test.revertedWith)
+                        } else {
+                            var burnedShares = parseShares(test.burnedShares)
+                            // event
+                            expect(await withdrawSubject)
+                                .to.emit(longToken, "Withdraw")
+                                .withArgs(caller.address, receiver.address, owner.address, withdrawAssets, burnedShares)
+
+                            // share
+                            expect(await longToken.totalSupply()).to.eq(totalSharesBefore.sub(burnedShares))
+                            expect(await longToken.balanceOf(owner_.address)).to.eq(ownerSharesBefore.sub(burnedShares))
+
+                            // asset
+                            expect(await longToken.totalAssets()).to.lt(totalAssetsBefore)
+                            expect(await weth.balanceOf(receiver.address)).to.eq(
+                                receiverAssetsBefore.add(withdrawAssets),
+                            )
+
+                            // preview >= burned
+                            expect(await previewSubject).to.eq(parseShares(test.burnedSharesPreview))
+                        }
+                    })
+                })
             })
         })
     })

--- a/test/longToken/withdraw.test.ts
+++ b/test/longToken/withdraw.test.ts
@@ -68,6 +68,10 @@ describe("PerpdexLongToken withdraw", async () => {
                 alice = fixture.alice
                 bob = fixture.bob
                 charlie = fixture.charlie
+
+                await weth.connect(owner).deposit({
+                    value: ethers.utils.parseEther("200"),
+                })
             })
 
             describe("maxWithdraw", async () => {

--- a/test/longToken/withdraw.test.ts
+++ b/test/longToken/withdraw.test.ts
@@ -110,7 +110,19 @@ describe("PerpdexLongToken withdraw", async () => {
 
                 await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)
 
-                expect(await longToken.maxWithdraw(alice.address)).to.eq(parseAssets(test.expected))
+                const maxWithdraw = await longToken.maxWithdraw(alice.address)
+                expect(maxWithdraw).to.eq(parseAssets(test.expected))
+
+                // check consistency
+                const previewSubject = longToken.connect(alice).previewWithdraw(maxWithdraw)
+                const withdrawSubject = longToken.connect(alice).withdraw(maxWithdraw, alice.address, alice.address)
+                if (maxWithdraw.gt(0)) {
+                    await expect(previewSubject).not.to.reverted
+                    await expect(withdrawSubject).not.to.reverted
+                } else {
+                    await expect(previewSubject).to.reverted
+                    await expect(withdrawSubject).to.reverted
+                }
             })
         })
     })

--- a/test/longToken/withdraw.test.ts
+++ b/test/longToken/withdraw.test.ts
@@ -99,7 +99,7 @@ describe("PerpdexLongToken withdraw", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // init pool
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
                 // alice deposits
                 await weth.connect(owner).mint(alice.address, parseAssets(test.depositAssets))
@@ -250,7 +250,7 @@ describe("PerpdexLongToken withdraw", async () => {
         ].forEach(test => {
             it(test.title, async () => {
                 // pool
-                await initPool(exchange, market, owner, parseShares(test.pool.base), parseAssets(test.pool.quote))
+                await initPool(fixture, parseShares(test.pool.base), parseAssets(test.pool.quote))
 
                 var caller = toWallet(test.caller)
                 var owner_ = toWallet(test.owner)

--- a/test/perpdexBaseToken/erc20.test.ts
+++ b/test/perpdexBaseToken/erc20.test.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { expect } from "chai"
+import { BigNumber, Wallet } from "ethers"
+import { ethers, waffle } from "hardhat"
+import { TestPerpdexTokenBase } from "../../typechain"
+import { createPerpdexTokenBaseFixture } from "./fixtures"
+
+describe("PerpdexTokenBase erc20", async () => {
+    let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+    let fixture
+
+    let tokenBase: TestPerpdexTokenBase
+    let alice: Wallet
+    let bob: Wallet
+
+    function toWallet(who: string) {
+        if (who === "alice") {
+            return alice
+        }
+        if (who === "bob") {
+            return bob
+        }
+    }
+
+    beforeEach(async () => {
+        fixture = await loadFixture(createPerpdexTokenBaseFixture())
+
+        tokenBase = fixture.perpdexTokenBase
+        alice = fixture.alice
+        bob = fixture.bob
+    })
+
+    describe("smoke test", async () => {
+        it("transfer", async () => {
+            await tokenBase.testMint(alice.address, 100)
+            await expect(tokenBase.connect(alice).transfer(bob.address, 30))
+                .to.emit(tokenBase, "Transfer")
+                .withArgs(alice.address, bob.address, 30)
+            expect(await tokenBase.balanceOf(bob.address)).to.eq(30)
+        })
+
+        it("increaseAllowance and transferFrom", async () => {
+            await tokenBase.testMint(alice.address, 100)
+            await tokenBase.connect(alice).increaseAllowance(bob.address, 30)
+            await expect(tokenBase.connect(bob).transferFrom(alice.address, bob.address, 30))
+                .to.emit(tokenBase, "Transfer")
+                .withArgs(alice.address, bob.address, 30)
+            expect(await tokenBase.balanceOf(bob.address)).to.eq(30)
+        })
+
+        it("increaseAllowance and decreaseAllowance", async () => {
+            await tokenBase.connect(alice).increaseAllowance(bob.address, 30)
+            await tokenBase.connect(alice).decreaseAllowance(bob.address, 30)
+        })
+    })
+})

--- a/test/perpdexBaseToken/fixtures.ts
+++ b/test/perpdexBaseToken/fixtures.ts
@@ -48,6 +48,7 @@ export function createPerpdexTokenBaseFixture(): (wallets, provider) => Promise<
             perpdexMarket.address,
             "TestToken",
             "TT",
+            ethers.constants.AddressZero,
         )) as TestPerpdexTokenBase
 
         return {


### PR DESCRIPTION
changes

- use latest deps/perpdex-contract
- test withdraw consistency
- fix maxWithdraw to use preview
- use openzeppelin Math.min
- move maxX implementation to long token contract
- add ETH support
- use ReentrancyGuard

todo

- test maxWithdraw all cases
  - preview revert case
  - maxTrade < previewTrade case 
- fix decimals tests
